### PR TITLE
일정 페이지 추가

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  styledComponents: true,
+  compiler: {
+    styledComponents: true,
+  },
 };
 
 export default nextConfig;

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -23,11 +23,13 @@ export const AccordionItem = ({ title, children }: AccordionItemProps) => {
 
   const willChange = useWillChange();
 
+  const isContentExist = Boolean(children);
+
   return (
     <AccordionItemContainer>
-      <AccordionItemHeader onClick={() => setIsOpen((prev) => !prev)}>
+      <AccordionItemHeader onClick={() => isContentExist && setIsOpen((prev) => !prev)}>
         {title && <AccordionItemTitle>{title}</AccordionItemTitle>}
-        <AccordionItemArrow name="arrow-down" isOpen={isOpen} />
+        {isContentExist && <AccordionItemArrow name="arrow-down" isOpen={isOpen} />}
       </AccordionItemHeader>
 
       <AnimatePresence initial={false}>

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,0 +1,16 @@
+import type { PropsWithChildren } from 'react';
+import React from 'react';
+import styled from 'styled-components';
+
+function Layout({ children }: PropsWithChildren) {
+  return <Container>{children}</Container>;
+}
+
+export default Layout;
+
+const Container = styled.div`
+  min-height: 100vh;
+  margin: 0 auto;
+  width: 100vw;
+  max-width: ${({ theme }) => theme.maxWidth};
+`;

--- a/src/features/schedule/ScheduleItem/index.stories.tsx
+++ b/src/features/schedule/ScheduleItem/index.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ScheduleItem from '.';
+
+const SCHEDULE = {
+  date: '2024-05-05',
+  isOffline: true,
+  title: '오리엔테이션',
+};
+
+const meta: Meta<typeof ScheduleItem> = {
+  title: 'schedule/ScheduleItem',
+  component: ScheduleItem,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{ width: '500px', padding: '16px', backgroundColor: '#F1F5F9' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    ...SCHEDULE,
+    week: 1,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ScheduleItem>;
+
+export const Today: Story = {
+  args: {
+    desc: "Yes. It's animated by default, but you can disable it if you prefer.",
+    isToday: true,
+  },
+};
+
+export const NotToday: Story = {
+  args: {
+    desc: "Yes. It's animated by default, but you can disable it if you prefer.",
+    isToday: false,
+  },
+};
+
+export const NoDesc: Story = {
+  args: {
+    isToday: false,
+  },
+};

--- a/src/features/schedule/ScheduleItem/index.tsx
+++ b/src/features/schedule/ScheduleItem/index.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Accordion, AccordionItem } from '@/components/Accordion';
+import { Badge } from '@/components/Badge';
+
+import type { ScheduleType } from '../index.constants';
+
+interface ScheduleItemProps extends ScheduleType {
+  week: number;
+  isToday?: boolean;
+}
+
+function ScheduleItem(props: ScheduleItemProps) {
+  return (
+    <Container>
+      <Head>
+        <HeadLeft>
+          <Badge variant="default">{props.week}주차</Badge>
+          <Title isToday={props.isToday}>{props.title}</Title>
+        </HeadLeft>
+        {props.isOffline ? <Badge variant="black">오프라인</Badge> : <Badge variant="line">온라인</Badge>}
+      </Head>
+      <Accordion>
+        <AccordionItem title={props.title}>{props.desc}</AccordionItem>
+      </Accordion>
+    </Container>
+  );
+}
+
+export default ScheduleItem;
+
+const Container = styled.div`
+  display: flex;
+  padding: 20px;
+  flex-direction: column;
+  gap: 24px;
+  border-radius: 12px;
+  background-color: ${({ theme }) => theme.color.white};
+`;
+
+const Head = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const HeadLeft = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+`;
+
+const Title = styled.p<Pick<ScheduleItemProps, 'isToday'>>`
+  ${({ theme }) => theme.typo.subtitle2};
+  position: relative;
+
+  &::after {
+    display: ${({ isToday }) => (isToday ? 'block' : 'none')};
+    content: '';
+    position: absolute;
+    top: 0;
+    right: -6px;
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background-color: ${({ theme }) => theme.color.gray_500};
+  }
+`;

--- a/src/features/schedule/index.constants.ts
+++ b/src/features/schedule/index.constants.ts
@@ -1,0 +1,44 @@
+export interface ScheduleType {
+  date: string;
+  isOffline?: boolean;
+  title: string;
+  desc?: string;
+}
+
+export const SCHEDULE_15TH: ScheduleType[] = [
+  {
+    date: '2024-05-05',
+    isOffline: true,
+    title: '오리엔테이션',
+    desc: "Yes. It's animated by default, but you can disable it if you prefer.",
+  },
+  {
+    date: '2024-06-02',
+    title: '아이디어 발표, MVP 설정',
+    desc: "Yes. It's animated by default, but you can disable it if you prefer.",
+  },
+  {
+    date: '2024-06-03',
+    title: '아이디어 발표, MVP 설정',
+  },
+  {
+    date: '2024-06-04',
+    title: '아이디어 발표, MVP 설정',
+    desc: "Yes. It's animated by default, but you can disable it if you prefer.",
+  },
+  {
+    date: '2024-06-05',
+    title: '아이디어 발표, MVP 설정',
+    desc: "Yes. It's animated by default, but you can disable it if you prefer.",
+  },
+  {
+    date: '2024-06-06',
+    title: '아이디어 발표, MVP 설정',
+    desc: "Yes. It's animated by default, but you can disable it if you prefer.",
+  },
+  {
+    date: '2024-06-07',
+    title: '아이디어 발표, MVP 설정',
+    desc: "Yes. It's animated by default, but you can disable it if you prefer.",
+  },
+];

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from 'styled-components';
 
 import QueryClientProvider from '@/apis/QueryClientProvider';
 import { pretendard } from '@/assets/fonts/font';
+import Layout from '@/components/Layout';
 import { SnackBarProvider } from '@/components/SnackBar/SnackBarProvider';
 import GlobalStyle from '@/styles/GlobalStyle';
 import theme from '@/styles/theme';
@@ -15,7 +16,9 @@ export default function App({ Component, pageProps }: AppProps) {
         <GlobalStyle />
         <LazyMotion features={domAnimation}>
           <SnackBarProvider />
-          <Component {...pageProps} className={pretendard.className} />
+          <Layout>
+            <Component {...pageProps} className={pretendard.className} />
+          </Layout>
         </LazyMotion>
       </ThemeProvider>
     </QueryClientProvider>

--- a/src/pages/schedule/index.tsx
+++ b/src/pages/schedule/index.tsx
@@ -1,0 +1,65 @@
+import styled from 'styled-components';
+
+import { SCHEDULE_15TH } from '@/features/schedule/index.constants';
+import ScheduleItem from '@/features/schedule/ScheduleItem';
+import { isSameDate } from '@/utils/date';
+
+function SchedulePage() {
+  const today = new Date();
+
+  return (
+    <PageLayout>
+      <Hgroup>
+        <h1>디프만 15기 일정</h1>
+        <hr />
+        <p>토요일 오후 2시~5시 진행</p>
+      </Hgroup>
+      {/* // TODO : 어떤것으로 key를 할지? */}
+      <ScheduleList>
+        {SCHEDULE_15TH.map((schedule, index) => {
+          const isToday = isSameDate(today, new Date(schedule.date));
+          return <ScheduleItem key={schedule.date} {...schedule} week={index + 1} isToday={isToday} />;
+        })}
+      </ScheduleList>
+    </PageLayout>
+  );
+}
+
+export default SchedulePage;
+
+const Hgroup = styled.hgroup`
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: flex-start;
+  margin-bottom: 24px;
+
+  > h1 {
+    color: ${({ theme }) => theme.color.gray_900};
+    ${({ theme }) => theme.typo.h2};
+  }
+  > hr {
+    width: 1px;
+    height: 16px;
+    color: ${({ theme }) => theme.color.gray_400};
+    margin: 0;
+  }
+
+  > p {
+    color: ${({ theme }) => theme.color.gray_600};
+    ${({ theme }) => theme.typo.caption};
+  }
+`;
+
+const PageLayout = styled.main`
+  height: 100%;
+  width: 100%;
+  background-color: ${({ theme }) => theme.color.gray_100};
+  padding: 32px 20px;
+`;
+
+const ScheduleList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -9,6 +9,7 @@ const theme = {
   typo,
   color,
   zIndex,
+  maxWidth: '475px',
 };
 
 export default theme;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,7 @@
+export const isSameDate = (date1: Date, date2: Date) => {
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDate() === date2.getDate()
+  );
+};


### PR DESCRIPTION
# 💡 기능
- styled component 가 ssr에서 안되던 오류를 수정했어요
- 아코디언 컴포넌트를 일부 수정했어요 (desc가 없을 경우 대응)
- theme에 max-width를 추가하고, layout 컴포넌트를 만들어 전체 화면에 적용될 수 있도록 하였습니다. (mobile만 고려하기 때문)
- 일정은 상수로 관리할 수 있도록 하고, 이를 이용해 일정 페이지를 구성하였어요. 
# 🔎 기타
<img width="375" alt="image" src="https://github.com/depromeet/depromeet-makers-fe/assets/49177223/3d0abfac-0c16-40e3-94a4-7f00e63c1098">
