### PR TITLE
로그인 페이지

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,6 @@
 {
   "parser": "@typescript-eslint/parser",
-  "plugins": [
-    "@typescript-eslint",
-    "unused-imports",
-    "simple-import-sort"
-  ],
+  "plugins": ["@typescript-eslint", "unused-imports", "simple-import-sort"],
   "extends": [
     "next/core-web-vitals",
     "plugin:@typescript-eslint/recommended",
@@ -21,9 +17,7 @@
       }
     ],
     "unused-imports/no-unused-imports": "error",
-    "unused-imports/no-unused-imports-ts": [
-      "error"
-    ],
+    "unused-imports/no-unused-imports-ts": ["error"],
     "unused-imports/no-unused-vars": [
       "warn",
       {
@@ -48,23 +42,10 @@
       "warn",
       {
         "groups": [
-          [
-            "^react",
-            "^next",
-            "^@?\\w"
-          ],
-          [
-            "@/(.*)"
-          ],
-          [
-            "^\\.\\.(?!/?$)",
-            "^\\.\\./?$"
-          ],
-          [
-            "^\\./(?=.*/)(?!/?$)",
-            "^\\.(?!/?$)",
-            "^\\./?$"
-          ]
+          ["^react", "^next", "^@?\\w"],
+          ["@/(.*)"],
+          ["^\\.\\.(?!/?$)", "^\\.\\./?$"],
+          ["^\\./(?=.*/)(?!/?$)", "^\\.(?!/?$)", "^\\./?$"]
         ]
       }
     ],
@@ -78,10 +59,9 @@
     "jsx-a11y/label-has-associated-control": [
       2,
       {
-        "labelAttributes": [
-          "htmlFor"
-        ]
+        "labelAttributes": ["htmlFor"]
       }
-    ]
+    ],
+    "jsx-a11y/no-autofocus": "off"
   }
 }

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -8,7 +8,7 @@ interface StyledProps {
 type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & StyledProps;
 
 function Button(props: Props) {
-  return <ButtonStyled {...props} />;
+  return <ButtonStyled {...props} onClick={(e) => !props.disabled && props.onClick?.(e)} />;
 }
 
 export default Button;
@@ -39,4 +39,11 @@ const ButtonStyled = styled.button<Partial<Props>>`
         `;
     }
   }}
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.color.gray_200};
+    border: 1px solid ${({ theme }) => theme.color.gray_200};
+    color: ${({ theme }) => theme.color.gray_400};
+    cursor: not-allowed;
+  }
 `;

--- a/src/features/login/CertifyStep.tsx
+++ b/src/features/login/CertifyStep.tsx
@@ -9,15 +9,13 @@ interface Props {
   onNext: () => void;
   onBack: () => void;
 }
-function JoinStep(props: Props) {
+
+function CertifyStep(props: Props) {
   const [value, setValue] = useState('');
-
-  const title = `비밀번호로 사용할 \n숫자 6자리를 입력해 주세요.`;
-
   return (
     <LoginLayout
       onBack={props.onBack}
-      title={title}
+      title="비밀번호를 입력해 주세요."
       buttonProps={{
         children: '다음',
         onClick: props.onNext,
@@ -29,4 +27,4 @@ function JoinStep(props: Props) {
   );
 }
 
-export default JoinStep;
+export default CertifyStep;

--- a/src/features/login/CertifyStep.tsx
+++ b/src/features/login/CertifyStep.tsx
@@ -5,6 +5,8 @@ import PasswordInput from './PasswordInput';
 
 const PASSWORD_LENGTH = 6;
 
+const dummy_password = '111111';
+
 interface Props {
   onNext: () => void;
   onBack: () => void;
@@ -12,17 +14,32 @@ interface Props {
 
 function CertifyStep(props: Props) {
   const [value, setValue] = useState('');
+
+  const isError = value.length === PASSWORD_LENGTH && value !== dummy_password;
+  const isDisabled = value.length !== PASSWORD_LENGTH || isError;
+
+  const onSubmit = () => {
+    // TODO: login API 연결
+    props.onNext();
+  };
+
   return (
     <LoginLayout
       onBack={props.onBack}
       title="비밀번호를 입력해 주세요."
       buttonProps={{
         children: '다음',
-        onClick: props.onNext,
-        disabled: value.length !== PASSWORD_LENGTH,
+        onClick: onSubmit,
+        disabled: isDisabled,
+        type: 'submit',
       }}
     >
-      <PasswordInput passwordLength={PASSWORD_LENGTH} inputLength={value.length} onChange={setValue} />
+      <PasswordInput
+        passwordLength={PASSWORD_LENGTH}
+        inputLength={value.length}
+        onChange={setValue}
+        error={isError ? '비밀번호가 일치하지 않습니다.' : undefined}
+      />
     </LoginLayout>
   );
 }

--- a/src/features/login/EmailStep.tsx
+++ b/src/features/login/EmailStep.tsx
@@ -32,7 +32,7 @@ function EmailStep(props: Props) {
         disabled: !email,
       }}
     >
-      <Input placeholder="이메일을 입력해주세요." value={email} onChange={(e) => setEmail(e.target.value)} />
+      <Input autoFocus placeholder="이메일을 입력해주세요." value={email} onChange={(e) => setEmail(e.target.value)} />
     </LoginLayout>
   );
 }

--- a/src/features/login/EmailStep.tsx
+++ b/src/features/login/EmailStep.tsx
@@ -15,7 +15,7 @@ function EmailStep(props: Props) {
   const onSubmit = () => {
     // TODO : email validation
     // 임시 valid
-    if (email.indexOf('login') === -1) {
+    if (email.indexOf('login') !== -1) {
       props.onNext('login');
     } else {
       props.onNext('join');

--- a/src/features/login/EmailStep.tsx
+++ b/src/features/login/EmailStep.tsx
@@ -24,7 +24,7 @@ function EmailStep(props: Props) {
 
   return (
     <LoginLayout
-      title="디프만 지원 시 사용했던 이메일을 입력해 주세요."
+      title={`디프만 지원 시 \n사용했던 이메일을 입력해 주세요.`}
       onBack={props.onBack}
       buttonProps={{
         children: '다음',

--- a/src/features/login/EmailStep.tsx
+++ b/src/features/login/EmailStep.tsx
@@ -5,12 +5,22 @@ import Input from '@/components/Input';
 import LoginLayout from './LoginLayout';
 
 interface Props {
-  onNext: () => void;
+  onNext: (type: 'join' | 'login') => void;
   onBack: () => void;
 }
 
 function EmailStep(props: Props) {
   const [email, setEmail] = useState('');
+
+  const onSubmit = () => {
+    // TODO : email validation
+    // 임시 valid
+    if (email.indexOf('login') === -1) {
+      props.onNext('login');
+    } else {
+      props.onNext('join');
+    }
+  };
 
   return (
     <LoginLayout
@@ -18,7 +28,7 @@ function EmailStep(props: Props) {
       onBack={props.onBack}
       buttonProps={{
         children: '다음',
-        onClick: props.onNext,
+        onClick: onSubmit,
         disabled: !email,
       }}
     >

--- a/src/features/login/EmailStep.tsx
+++ b/src/features/login/EmailStep.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+
+import Input from '@/components/Input';
+
+import LoginLayout from './LoginLayout';
+
+interface Props {
+  onNext: () => void;
+  onBack: () => void;
+}
+
+function EmailStep(props: Props) {
+  const [email, setEmail] = useState('');
+
+  return (
+    <LoginLayout
+      title="디프만 지원 시 사용했던 이메일을 입력해 주세요."
+      onBack={props.onBack}
+      buttonProps={{
+        children: '다음',
+        onClick: props.onNext,
+        disabled: !email,
+      }}
+    >
+      <Input placeholder="이메일을 입력해주세요." value={email} onChange={(e) => setEmail(e.target.value)} />
+    </LoginLayout>
+  );
+}
+
+export default EmailStep;

--- a/src/features/login/JoinCompleteStep.tsx
+++ b/src/features/login/JoinCompleteStep.tsx
@@ -1,0 +1,20 @@
+import LoginLayout from './LoginLayout';
+
+interface Props {
+  onNext: () => void;
+}
+
+function JoinCompleteStep(props: Props) {
+  return (
+    <LoginLayout
+      title="디프만 메이커스 가입 완료!"
+      desc={`다시한번 디프만에 오신 걸 환영해요.\n지금 바로 디프만 메이커스를 사용해보세요.`}
+      buttonProps={{
+        children: '홈으로 바로가기',
+        onClick: props.onNext,
+      }}
+    ></LoginLayout>
+  );
+}
+
+export default JoinCompleteStep;

--- a/src/features/login/JoinStep.tsx
+++ b/src/features/login/JoinStep.tsx
@@ -11,7 +11,8 @@ interface Props {
 function JoinStep(props: Props) {
   const [value, setValue] = useState('');
 
-  const title = '비밀번호로 사용할 숫자 6자리를 입력해 주세요.';
+  const title = `비밀번호로 사용할 \n숫자 6자리를 입력해 주세요.`;
+
   return (
     <LoginLayout
       onBack={props.onBack}
@@ -22,12 +23,7 @@ function JoinStep(props: Props) {
         disabled: value.length !== PASSWORD_LENGTH,
       }}
     >
-      <PasswordInput
-        passwordLength={PASSWORD_LENGTH}
-        inputLength={value.length}
-        onChange={setValue}
-        error={value.length !== PASSWORD_LENGTH ? '비밀번호를 입력해 주세요.' : undefined}
-      />
+      <PasswordInput passwordLength={PASSWORD_LENGTH} inputLength={value.length} onChange={setValue} />
     </LoginLayout>
   );
 }

--- a/src/features/login/JoinStep.tsx
+++ b/src/features/login/JoinStep.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+import LoginLayout from './LoginLayout';
+import PasswordInput from './PasswordInput';
+
+const PASSWORD_LENGTH = 6;
+interface Props {
+  onNext: () => void;
+  onBack: () => void;
+}
+function JoinStep(props: Props) {
+  const [value, setValue] = useState('');
+
+  const title = '비밀번호로 사용할 숫자 6자리를 입력해 주세요.';
+  return (
+    <LoginLayout
+      onBack={props.onBack}
+      title={title}
+      buttonProps={{
+        children: '다음',
+        onClick: props.onNext,
+        disabled: value.length !== PASSWORD_LENGTH,
+      }}
+    >
+      <PasswordInput
+        passwordLength={PASSWORD_LENGTH}
+        inputLength={value.length}
+        onChange={setValue}
+        error={value.length !== PASSWORD_LENGTH ? '비밀번호를 입력해 주세요.' : undefined}
+      />
+    </LoginLayout>
+  );
+}
+
+export default JoinStep;

--- a/src/features/login/JoinStep.tsx
+++ b/src/features/login/JoinStep.tsx
@@ -63,8 +63,8 @@ function PasswordInputStep(props: { onBack: () => void; onNext: (value: string) 
 function PasswordInputConfirmStep(props: { onBack: () => void; onNext: () => void; password: string }) {
   const [input, setInput] = useState('');
 
-  const isDisabled = input.length !== PASSWORD_LENGTH;
   const isError = input.length === PASSWORD_LENGTH && input !== props.password;
+  const isDisabled = input.length !== PASSWORD_LENGTH || isError;
 
   return (
     <LoginLayout
@@ -73,7 +73,7 @@ function PasswordInputConfirmStep(props: { onBack: () => void; onNext: () => voi
       buttonProps={{
         children: '다음',
         onClick: props.onNext,
-        disabled: isDisabled || isError,
+        disabled: isDisabled,
         type: 'submit',
       }}
     >

--- a/src/features/login/JoinStep.tsx
+++ b/src/features/login/JoinStep.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import LoginLayout from './LoginLayout';
 import PasswordInput from './PasswordInput';
@@ -9,24 +9,80 @@ interface Props {
   onNext: () => void;
   onBack: () => void;
 }
-function JoinStep(props: Props) {
-  const [value, setValue] = useState('');
 
-  const title = `비밀번호로 사용할 \n숫자 6자리를 입력해 주세요.`;
+function JoinStep(props: Props) {
+  const [isConfirmStep, setIsConfirmStep] = useState(false);
+  const passwordValueRef = useRef<string>();
+
+  const onSubmit = () => {
+    // TODO : API 연결
+    props.onNext();
+  };
+
+  if (isConfirmStep && passwordValueRef.current)
+    return (
+      <PasswordInputConfirmStep
+        onBack={() => setIsConfirmStep(false)}
+        onNext={onSubmit}
+        password={passwordValueRef.current}
+      />
+    );
 
   return (
-    <LoginLayout
+    <PasswordInputStep
       onBack={props.onBack}
-      title={title}
-      buttonProps={{
-        children: '다음',
-        onClick: props.onNext,
-        disabled: value.length !== PASSWORD_LENGTH,
+      onNext={(input) => {
+        passwordValueRef.current = input;
+        setIsConfirmStep(true);
       }}
-    >
-      <PasswordInput passwordLength={PASSWORD_LENGTH} inputLength={value.length} onChange={setValue} />
-    </LoginLayout>
+    />
   );
 }
 
 export default JoinStep;
+
+function PasswordInputStep(props: { onBack: () => void; onNext: (value: string) => void }) {
+  const [input, setInput] = useState('');
+
+  return (
+    <LoginLayout
+      onBack={props.onBack}
+      title={`비밀번호로 사용할 \n숫자 6자리를 입력해 주세요.`}
+      buttonProps={{
+        children: '다음',
+        onClick: () => props.onNext(input),
+        disabled: input.length !== PASSWORD_LENGTH,
+        type: 'submit',
+      }}
+    >
+      <PasswordInput passwordLength={PASSWORD_LENGTH} inputLength={input.length} onChange={setInput} />
+    </LoginLayout>
+  );
+}
+
+function PasswordInputConfirmStep(props: { onBack: () => void; onNext: () => void; password: string }) {
+  const [input, setInput] = useState('');
+
+  const isDisabled = input.length !== PASSWORD_LENGTH;
+  const isError = input.length === PASSWORD_LENGTH && input !== props.password;
+
+  return (
+    <LoginLayout
+      onBack={props.onBack}
+      title={`동일한 비밀번호를\n한번 더 입력해 주세요.`}
+      buttonProps={{
+        children: '다음',
+        onClick: props.onNext,
+        disabled: isDisabled || isError,
+        type: 'submit',
+      }}
+    >
+      <PasswordInput
+        passwordLength={PASSWORD_LENGTH}
+        inputLength={input.length}
+        onChange={setInput}
+        error={isError ? '비밀번호가 일치하지 않습니다.' : undefined}
+      />
+    </LoginLayout>
+  );
+}

--- a/src/features/login/LoginLayout.tsx
+++ b/src/features/login/LoginLayout.tsx
@@ -1,0 +1,74 @@
+import type { ComponentProps, PropsWithChildren } from 'react';
+import React from 'react';
+import styled from 'styled-components';
+
+import Button from '@/components/Button';
+import Icon from '@/components/Icon';
+
+interface Props {
+  title: string;
+  desc?: string;
+  onBack?: () => void;
+  buttonProps: {
+    children: string;
+    onClick: () => void;
+  } & ComponentProps<typeof Button>;
+}
+
+function LoginLayout(props: PropsWithChildren<Props>) {
+  return (
+    <Main>
+      {props.onBack && (
+        <Header>
+          <button onClick={props.onBack}>
+            <Icon name="arrow-left" />
+          </button>
+        </Header>
+      )}
+      <Hgroup>
+        <Heading>{props.title}</Heading>
+        {props.desc && <Desc>{props.desc}</Desc>}
+      </Hgroup>
+      {props.children}
+      <ButtonWrapper>
+        <Button {...props.buttonProps} />
+      </ButtonWrapper>
+    </Main>
+  );
+}
+
+export default LoginLayout;
+
+const Main = styled.main`
+  padding: 20px;
+`;
+
+const Header = styled.header``;
+
+const Hgroup = styled.hgroup`
+  margin-bottom: 32px;
+  margin-top: 60px;
+  max-width: 230px;
+`;
+
+const Heading = styled.h2`
+  ${({ theme }) => theme.typo.h2};
+  color: ${({ theme }) => theme.color.gray_900};
+`;
+
+const Desc = styled.p`
+  margin-top: 12px;
+  ${({ theme }) => theme.typo.p};
+  color: ${({ theme }) => theme.color.gray_500};
+`;
+
+const ButtonWrapper = styled.div`
+  position: fixed;
+  bottom: 48px;
+  width: 100%;
+  max-width: ${({ theme }) => `calc(${theme.maxWidth} - 40px)`};
+
+  button {
+    width: 100%;
+  }
+`;

--- a/src/features/login/LoginLayout.tsx
+++ b/src/features/login/LoginLayout.tsx
@@ -48,7 +48,7 @@ const Header = styled.header``;
 const Hgroup = styled.hgroup`
   margin-bottom: 32px;
   margin-top: 60px;
-  max-width: 230px;
+  white-space: pre;
 `;
 
 const Heading = styled.h2`

--- a/src/features/login/LoginLayout.tsx
+++ b/src/features/login/LoginLayout.tsx
@@ -65,8 +65,11 @@ const Desc = styled.p`
 const ButtonWrapper = styled.div`
   position: fixed;
   bottom: 48px;
+  left: 0;
+  right: 0;
   width: 100%;
-  max-width: ${({ theme }) => `calc(${theme.maxWidth} - 40px)`};
+  padding: 0 20px;
+  max-width: ${({ theme }) => theme.maxWidth};
 
   button {
     width: 100%;

--- a/src/features/login/PasswordInput.tsx
+++ b/src/features/login/PasswordInput.tsx
@@ -12,6 +12,7 @@ function PasswordInput(props: Props) {
   return (
     <DotContainer>
       <Input
+        autoFocus
         type="number"
         maxLength={props.passwordLength}
         onChange={(e) => e.target.value.length <= props.passwordLength && props.onChange(e.target.value)}

--- a/src/features/login/PasswordInput.tsx
+++ b/src/features/login/PasswordInput.tsx
@@ -11,7 +11,11 @@ interface Props {
 function PasswordInput(props: Props) {
   return (
     <DotContainer>
-      <Input type="number" maxLength={props.passwordLength} onChange={(e) => props.onChange(e.target.value)} />
+      <Input
+        type="number"
+        maxLength={props.passwordLength}
+        onChange={(e) => e.target.value.length <= props.passwordLength && props.onChange(e.target.value)}
+      />
       {Array.from({ length: props.passwordLength }, (_, index) => (
         <Dot key={index} isChecked={index < props.inputLength} />
       ))}
@@ -35,8 +39,9 @@ const Input = styled.input`
   left: 0;
   position: absolute;
   width: 100%;
-  opacity: 0;
+  top: 16px;
   height: 20px;
+  opacity: 0;
 `;
 
 const Dot = styled.div<{ isChecked: boolean }>`

--- a/src/features/login/PasswordInput.tsx
+++ b/src/features/login/PasswordInput.tsx
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+
+interface Props {
+  passwordLength: number;
+  inputLength: number;
+  onChange: (value: string) => void;
+
+  error?: string;
+}
+
+function PasswordInput(props: Props) {
+  return (
+    <DotContainer>
+      <Input type="number" maxLength={props.passwordLength} onChange={(e) => props.onChange(e.target.value)} />
+      {Array.from({ length: props.passwordLength }, (_, index) => (
+        <Dot key={index} isChecked={index < props.inputLength} />
+      ))}
+      {props.error && <ErrorStyled>{props.error}</ErrorStyled>}
+    </DotContainer>
+  );
+}
+
+export default PasswordInput;
+
+const DotContainer = styled.div`
+  position: relative;
+  display: flex;
+  gap: 16px;
+  padding: 16px 0;
+  width: fit-content;
+`;
+
+const Input = styled.input`
+  top: 0;
+  left: 0;
+  position: absolute;
+  width: 100%;
+  opacity: 0;
+  height: 20px;
+`;
+
+const Dot = styled.div<{ isChecked: boolean }>`
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background-color: ${({ theme, isChecked }) => (isChecked ? theme.color.gray_600 : theme.color.gray_200)};
+  margin: 0 4px;
+`;
+
+const ErrorStyled = styled.p`
+  position: absolute;
+  top: 48px;
+  left: 0;
+  ${({ theme }) => theme.typo.caption};
+  color: ${({ theme }) => theme.color.red_300};
+`;

--- a/src/features/login/WelcomStep.tsx
+++ b/src/features/login/WelcomStep.tsx
@@ -8,15 +8,13 @@ interface Props {
 function WelcomeStep(props: Props) {
   return (
     <LoginLayout
-      title="간편한 디프만 출석체크, 한눈에 관리해보세요!"
+      title={`간편한 디프만 출석체크,\n한눈에 관리해보세요!`}
       desc="출석 체크부터 출결 관리까지"
       buttonProps={{
         children: '입장하기',
         onClick: props.onNext,
       }}
-    >
-      {/* <Heading>간편한 디프만 출석체크, 한눈에 관리해보세요!</Heading> */}
-    </LoginLayout>
+    ></LoginLayout>
   );
 }
 

--- a/src/features/login/WelcomStep.tsx
+++ b/src/features/login/WelcomStep.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import LoginLayout from './LoginLayout';
+
+interface Props {
+  onNext: () => void;
+}
+function WelcomeStep(props: Props) {
+  return (
+    <LoginLayout
+      title="간편한 디프만 출석체크, 한눈에 관리해보세요!"
+      desc="출석 체크부터 출결 관리까지"
+      buttonProps={{
+        children: '입장하기',
+        onClick: props.onNext,
+      }}
+    >
+      {/* <Heading>간편한 디프만 출석체크, 한눈에 관리해보세요!</Heading> */}
+    </LoginLayout>
+  );
+}
+
+export default WelcomeStep;

--- a/src/hooks/useFunnel.tsx
+++ b/src/hooks/useFunnel.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement, ReactNode } from 'react';
+import React, { useState } from 'react';
+
+export interface StepProps {
+  name: string;
+  children: ReactNode;
+}
+
+export interface FunnelProps {
+  children: Array<ReactElement<StepProps>>;
+}
+
+export const useFunnel = (defaultStep: string) => {
+  const [step, setStep] = useState(defaultStep);
+
+  const Step = (props: StepProps): ReactElement => {
+    return <>{props.children}</>;
+  };
+
+  const Funnel = ({ children }: FunnelProps) => {
+    const targetStep = children.find((childStep) => childStep.props.name === step);
+
+    return <>{targetStep}</>;
+  };
+
+  return { Funnel, Step, setStep, currentStep: step } as const;
+};

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -15,9 +15,14 @@ function LoginPage() {
           <WelcomeStep onNext={() => setStep(STEP[1])} />
         </Step>
         <Step name={STEP[1]}>
-          <EmailStep onBack={() => setStep(STEP[0])} onNext={() => setStep(STEP[2])} />
+          <EmailStep
+            onBack={() => setStep(STEP[0])}
+            onNext={(type) => (type === 'join' ? setStep(STEP[2]) : setStep(STEP[4]))}
+          />
         </Step>
         <Step name={STEP[2]}>Join</Step>
+        <Step name={STEP[3]}>Join Complete</Step>
+        <Step name={STEP[4]}>Certify</Step>
       </Funnel>
     </div>
   );

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import EmailStep from '@/features/login/EmailStep';
+import WelcomeStep from '@/features/login/WelcomStep';
+import { useFunnel } from '@/hooks/useFunnel';
+
+const STEP = ['welcome', 'email', 'join', 'join-complete', 'certify'];
+function LoginPage() {
+  const { Funnel, Step, setStep } = useFunnel(STEP[0]);
+
+  return (
+    <div>
+      <Funnel>
+        <Step name={STEP[0]}>
+          <WelcomeStep onNext={() => setStep(STEP[1])} />
+        </Step>
+        <Step name={STEP[1]}>
+          <EmailStep onBack={() => setStep(STEP[0])} onNext={() => setStep(STEP[2])} />
+        </Step>
+        <Step name={STEP[2]}>Join</Step>
+      </Funnel>
+    </div>
+  );
+}
+
+export default LoginPage;

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useRouter } from 'next/router';
 
+import CertifyStep from '@/features/login/CertifyStep';
 import EmailStep from '@/features/login/EmailStep';
 import JoinCompleteStep from '@/features/login/JoinCompleteStep';
 import JoinStep from '@/features/login/JoinStep';
@@ -30,7 +31,9 @@ function LoginPage() {
         <Step name={STEP[3]}>
           <JoinCompleteStep onNext={() => router.push('/')} />
         </Step>
-        <Step name={STEP[4]}>Certify</Step>
+        <Step name={STEP[4]}>
+          <CertifyStep onNext={() => router.push('/')} onBack={() => setStep(STEP[1])} />
+        </Step>
       </Funnel>
     </div>
   );

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import EmailStep from '@/features/login/EmailStep';
+import JoinStep from '@/features/login/JoinStep';
 import WelcomeStep from '@/features/login/WelcomStep';
 import { useFunnel } from '@/hooks/useFunnel';
 
@@ -20,7 +21,9 @@ function LoginPage() {
             onNext={(type) => (type === 'join' ? setStep(STEP[2]) : setStep(STEP[4]))}
           />
         </Step>
-        <Step name={STEP[2]}>Join</Step>
+        <Step name={STEP[2]}>
+          <JoinStep onBack={() => setStep(STEP[1])} onNext={() => setStep(STEP[3])} />
+        </Step>
         <Step name={STEP[3]}>Join Complete</Step>
         <Step name={STEP[4]}>Certify</Step>
       </Funnel>

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import { useRouter } from 'next/router';
 
 import EmailStep from '@/features/login/EmailStep';
+import JoinCompleteStep from '@/features/login/JoinCompleteStep';
 import JoinStep from '@/features/login/JoinStep';
 import WelcomeStep from '@/features/login/WelcomStep';
 import { useFunnel } from '@/hooks/useFunnel';
 
 const STEP = ['welcome', 'email', 'join', 'join-complete', 'certify'];
 function LoginPage() {
+  const router = useRouter();
   const { Funnel, Step, setStep } = useFunnel(STEP[0]);
 
   return (
@@ -24,7 +27,9 @@ function LoginPage() {
         <Step name={STEP[2]}>
           <JoinStep onBack={() => setStep(STEP[1])} onNext={() => setStep(STEP[3])} />
         </Step>
-        <Step name={STEP[3]}>Join Complete</Step>
+        <Step name={STEP[3]}>
+          <JoinCompleteStep onNext={() => router.push('/')} />
+        </Step>
         <Step name={STEP[4]}>Certify</Step>
       </Funnel>
     </div>

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -9,6 +9,7 @@ const theme = {
   typo,
   color,
   zIndex,
+  maxWidth: '475px',
 };
 
 export default theme;


### PR DESCRIPTION
# 💡 기능
- 로그인의 각 스탭을 Funnel을 이용해 관리하였어요. 
- 이메일 입력 스텝에서 'login'을 입력하면 로그인 스텝으로, 그렇지 않은 값을 입력하면 회원가입 스텝으로 이동합니다. 
- 로그인 스텝의 임시 비밀번호는 111111입니다. 
- 나중에 API 연결만 이어서 하면 될것 같아욤
- 사용성을 위해 input에 auto focus를 걸어두었어요. 그런데 eslint에서 막아서 설정을 꺼버렸는데 괜찮을까요?

# 🔎 기타
![May-08-2024 21-33-53](https://github.com/depromeet/depromeet-makers-fe/assets/49177223/807ba4c4-8fc9-4955-a386-cc5004d4d297)

