### PR TITLE
홈 페이지 추가

### DIFF
--- a/src/components/BottomNav/index.tsx
+++ b/src/components/BottomNav/index.tsx
@@ -11,7 +11,7 @@ type NavItemProps = {
 
 const NAV_ITEMS = [
   // TODO: path 수정 필요
-  { text: '홈', icon: 'home', path: '' },
+  { text: '홈', icon: 'home', path: '/home' },
   { text: '일정', icon: 'calendar', path: '' },
   { text: '마이페이지', icon: 'user', path: '' },
 ] as const;
@@ -38,12 +38,16 @@ export const BottomNav = () => {
 const BottomNavStyled = styled.nav`
   position: fixed;
   bottom: 0;
+  left: 50%;
+  transform: translate(-50%, 0);
 
   display: flex;
   justify-content: space-evenly;
-  width: 100%;
+  width: ${({ theme }) => theme.size.maxWidth};
   padding: 12px 0;
+  z-index: ${({ theme }) => theme.zIndex.bottomNav};
 
+  background-color: ${({ theme }) => theme.color.white};
   border-top: 1px solid ${({ theme }) => theme.color.gray_200};
 `;
 

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,0 +1,83 @@
+import styled from 'styled-components';
+
+import { Badge } from '@/components/Badge';
+import { BottomNav } from '@/components/BottomNav';
+import { FAB } from '@/components/FAB';
+import { Absence } from '@/features/home/Absence';
+import { Attendance } from '@/features/home/Attendance';
+import { RuleLink } from '@/features/home/RuleLink';
+
+const Home = () => {
+  // TODO: 응답 값으로 수정 필요
+  const title = `디프만 15기 첫출발,\n함께 시작해 볼까요? 🌱`;
+  const week = '1주차';
+  const date = '4월 3일';
+  const isVisibleFab = true;
+
+  return (
+    <>
+      <Container>
+        <InfoContainer>
+          <DateContainer>
+            <Badge>{week}</Badge>
+            <DateText>{date}</DateText>
+          </DateContainer>
+          <RuleLink />
+        </InfoContainer>
+
+        <Title>{title}</Title>
+
+        <AttendanceContainer>
+          <Attendance />
+          <Absence />
+        </AttendanceContainer>
+      </Container>
+
+      {isVisibleFab && <FAB text="출석하기 🙌" subText="세션이 시작되었습니다." />}
+      <BottomNav />
+    </>
+  );
+};
+
+const Container = styled.main`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+
+  padding-top: 32px;
+`;
+
+const InfoContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  margin-bottom: 12px;
+`;
+
+const DateContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const DateText = styled.p`
+  ${({ theme }) => theme.typo.subtitle2};
+  color: ${({ theme }) => theme.color.gray_700};
+`;
+
+const Title = styled.h2`
+  ${({ theme }) => theme.typo.h2};
+  color: ${({ theme }) => theme.color.gray_900};
+  line-height: 34px;
+
+  margin-bottom: 20px;
+`;
+
+const AttendanceContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+export default Home;

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -6,6 +6,7 @@ const GlobalStyle = createGlobalStyle`
 
   *, *::before, *::after {
     box-sizing: border-box;
+    white-space: pre-line;
   }
 
   body {

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -3,8 +3,9 @@ import typo from './typo';
 
 const zIndex = {
   fab: 999,
-  backdrop: 1000,
-  modal: 1001,
+  bottomNav: 1000,
+  backdrop: 1001,
+  modal: 1002,
 };
 
 const theme = {


### PR DESCRIPTION
# 💡 기능

- 세션 출석과 출석 상태를 보여주는 홈 화면을 추가했어요
   - 임시 데이터로 레이아웃만 잡았어요 
   - 스낵바 팝업은 추후에 추가하는게 좋을 것 같아서 우선 제외했어요

# 🔎 기타

- 피그마에는 375px 기준으로 되어있어서 추후 출석 현황판 비율 수정 필요 

<img width="351" alt="스크린샷 2024-05-07 오후 7 37 07" src="https://github.com/depromeet/depromeet-makers-fe/assets/80238096/6ad10b49-55cc-468b-9974-c92e3f846fbd">

