### PR TITLE
스크롤 위치에 따라 간소화된 헤더를 보여주도록

### DIFF
--- a/src/features/admin/attendance/StatusSelect.tsx
+++ b/src/features/admin/attendance/StatusSelect.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { AnimatePresence, m } from 'framer-motion';
 import styled, { useTheme } from 'styled-components';
 
@@ -22,24 +22,37 @@ function StatusSelect(props: Props) {
   const [dropdownPosition, setDropdownPosition] = useState<DropdownPosition>();
   const [isShowing, setIsShowing] = useState(false);
 
-  useEffect(() => {
+  const getPosition = useCallback(() => {
     if (selectRef.current) {
-      const { bottom } = selectRef.current.getBoundingClientRect();
+      const { top, bottom } = selectRef.current.getBoundingClientRect();
       const windowHeight = window.innerHeight;
 
-      const DROPDOWN_HEIGHT = 230;
-
-      if (windowHeight - bottom < DROPDOWN_HEIGHT) {
-        setDropdownPosition('top');
-      } else {
-        setDropdownPosition('bottom');
+      const DROPDOWN_HEIGHT = 230 + 64;
+      if (top < DROPDOWN_HEIGHT) {
+        return 'bottom';
       }
+      if (windowHeight - bottom < DROPDOWN_HEIGHT) {
+        return 'top';
+      }
+      return 'bottom';
     }
-  }, [selectRef.current]);
+  }, [selectRef.current?.getBoundingClientRect()]);
+
+  useEffect(() => {
+    if (selectRef.current) {
+      const position = getPosition();
+      setDropdownPosition(position);
+    }
+  }, [getPosition]);
 
   return (
     <Container ref={selectRef}>
-      <Label onClick={() => setIsShowing((prev) => !prev)} status={props.value}>
+      <Label
+        onClick={() => {
+          setIsShowing((prev) => !prev);
+        }}
+        status={props.value}
+      >
         <span>{props.value}</span>
         <Icon name="arrow-down" color={theme.color.gray_400} width={16} height={16} />
       </Label>

--- a/src/pages/admin/attendance.tsx
+++ b/src/pages/admin/attendance.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { m } from 'framer-motion';
 import styled from 'styled-components';
 
 import IconButton from '@/components/Button/IconButton';
@@ -9,20 +10,33 @@ import UserItem from '@/features/admin/attendance/UserItem';
 import WeekSelect from '@/features/admin/attendance/WeekSelect';
 
 function AdminAttendancePage() {
+  const { ref, isViewMiniHeader } = useScrollAction();
+
   const [week, setWeek] = useState(1);
   const [team, setTeam] = useState(1);
 
   return (
     <Layout>
       <Main>
-        <TopSection>
-          <WeekSelect value={week} onChange={(week) => setWeek(week)} />
-          <IconButton iconName="state">전체 출석률</IconButton>
-        </TopSection>
-        <TeamSection>
-          <TeamSelect value={team} onChange={(team) => setTeam(team)} />
-        </TeamSection>
-        <UserSection>
+        {isViewMiniHeader ? (
+          <>
+            <MiniHeaderBlank />
+            <MiniHeader initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+              {week}주차 - {team}팀
+            </MiniHeader>
+          </>
+        ) : (
+          <>
+            <TopSection>
+              <WeekSelect value={week} onChange={(week) => setWeek(week)} />
+              <IconButton iconName="state">전체 출석률</IconButton>
+            </TopSection>
+            <TeamSection>
+              <TeamSelect value={team} onChange={(team) => setTeam(team)} />
+            </TeamSection>
+          </>
+        )}
+        <UserSection ref={ref}>
           {DUMMY_DATA.map((data) => (
             <UserItem key={data.id} {...data} />
           ))}
@@ -32,7 +46,55 @@ function AdminAttendancePage() {
   );
 }
 
+// UserSection 컴포넌트가 일정 높이 이상 스크롤이 되면, 상단에 고정된 간소화된 헤더가 보여지도록 구현
+const MINI_HEADER_TRIGGER = 112;
+
+const useScrollAction = () => {
+  const [isViewMiniHeader, setIsViewMiniHeader] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleScroll = useCallback(() => {
+    if (!ref.current) return;
+
+    const top = ref.current.getBoundingClientRect().top;
+
+    setIsViewMiniHeader(top <= MINI_HEADER_TRIGGER);
+  }, []);
+
+  useEffect(() => {
+    if (!ref.current) return;
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [handleScroll]);
+
+  return { ref, isViewMiniHeader };
+};
+
 export default AdminAttendancePage;
+
+const MiniHeader = styled(m.header)`
+  height: 64px;
+  text-align: center;
+  line-height: 64px;
+  background-color: ${({ theme }) => theme.color.gray_100};
+  ${({ theme }) => theme.typo.title1};
+  color: ${({ theme }) => theme.color.gray_900};
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  z-index: ${({ theme }) => theme.zIndex.header};
+`;
+
+const MiniHeaderBlank = styled.div`
+  height: 112px;
+  background: transparent;
+`;
 
 const Main = styled.main`
   width: 100%;
@@ -104,6 +166,24 @@ const DUMMY_DATA: {
   },
   {
     id: 7,
+    name: '박지민',
+    position: '디자이너',
+    status: ATTENDANCE_STATUS.출석대기,
+  },
+  {
+    id: 8,
+    name: '박지민',
+    position: '디자이너',
+    status: ATTENDANCE_STATUS.출석대기,
+  },
+  {
+    id: 9,
+    name: '박지민',
+    position: '디자이너',
+    status: ATTENDANCE_STATUS.출석대기,
+  },
+  {
+    id: 10,
     name: '박지민',
     position: '디자이너',
     status: ATTENDANCE_STATUS.출석대기,

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -4,6 +4,7 @@ import typo from './typo';
 const zIndex = {
   dropdown: 10,
   fab: 999,
+  header: 1000,
   bottomNav: 1000,
   backdrop: 1001,
   modal: 1002,


### PR DESCRIPTION
# 💡 기능
- 스크롤 위치에 따라 간소화된 헤더를 보여줄 수 있도록 하였어요 @진승희 언니의 요청
- 드롭다운 위치를 잡는 부분에 오류가 있어 수정했습니다. (스크롤 이후의 위치를 재계산하지 않음)
# 🔎 기타
![May-09-2024 21-57-22](https://github.com/depromeet/depromeet-makers-fe/assets/49177223/da397be8-1640-4845-b161-66660af2597c)
