### PR TITLE
QA 텍스트 수정 및 플로팅 버튼 영역 수정

### DIFF
--- a/src/components/FAB/index.tsx
+++ b/src/components/FAB/index.tsx
@@ -17,7 +17,7 @@ export const FAB = ({ subText, text, children, ...props }: FABProps) => {
 };
 
 const FABStyled = styled.button`
-  position: absolute;
+  position: fixed;
   left: 50%;
   bottom: 108px;
   transform: translate(-50%, 0%);

--- a/src/features/home/Attendance/index.tsx
+++ b/src/features/home/Attendance/index.tsx
@@ -31,7 +31,7 @@ export const Attendance = () => {
     <Container>
       <Title>
         <Text>출석 현황</Text>
-        {isBefore15Min && <SubText>세션 시작 15분전입니다. 정각에 새로고침 해주세요.</SubText>}
+        {isBefore15Min && <SubText>15분전입니다. 정각에 새로고침 해주세요.</SubText>}
       </Title>
 
       <Grid>


### PR DESCRIPTION
# 💡 기능

- [세션 시작 15분 전 텍스트 넘쳐보일 수 있어서 텍스트 수정 필요](https://www.notion.so/depromeet/15-9ecad07e57e8474e995d775573b0eac9?pvs=4)
   -  `세션 시작 15분전입니다. 정각에 새로고침해주세요.` -> `15분전입니다. 정각에 새로고침해주세요.`
- [메인 스크롤 영역 및 플로팅 버튼](https://www.notion.so/depromeet/cceeecc997384f61b8dc2e7530e52919?pvs=4)
    -  ![image](https://github.com/depromeet/depromeet-makers-fe/assets/80238096/ef5e105c-5269-4402-a489-2145820f0ec5)




# 🔎 기타
