### PR TITLE
styled component ssr 대응

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-error.log*
 next-env.d.ts
 
 *storybook.log
+.env

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,13 +1,38 @@
+import type { DocumentContext, DocumentInitialProps } from 'next/document';
 import { Head, Html, Main, NextScript } from 'next/document';
+import Document from 'next/document';
+import { ServerStyleSheet } from 'styled-components';
 
-export default function Document() {
-  return (
-    <Html lang="kr">
-      <Head />
-      <body>
-        <Main />
-        <NextScript />
-      </body>
-    </Html>
-  );
+export default class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
+        });
+
+      const initialProps = await Document.getInitialProps(ctx);
+      return {
+        ...initialProps,
+        styles: [initialProps.styles, sheet.getStyleElement()],
+      };
+    } finally {
+      sheet.seal();
+    }
+  }
+
+  render() {
+    return (
+      <Html lang="kr">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
 }


### PR DESCRIPTION
# 💡 기능
styled-component ssr 대응을 했는데도 (next.config.ts 수정) 왜 자꾸 스타일이 버벅거리지 했는데, 알고보니 반만 대응한거였어
우리 환경은 next 14v + styled componet + swc 니까
https://styled-components.com/docs/advanced#with-swc 이 링크를 참고해서 `_document.tsx` 파일을 수정했어

추가적으로 `_document.tsx` 파일이 원래 함수형으로 되어있었는데, 이 파일은 무조건 클래스형으로 만들어야한대. 
그래서 함수형을 클래스형으로 변경하고, styled component ssr 대응도 추가했어
참고 : https://merrily-code.tistory.com/154

![스크린샷 2024-05-17 오후 4 36 57](https://github.com/depromeet/depromeet-makers-fe/assets/49177223/5aeb9a84-4767-4e53-a91d-7d225c34c193)

# 🔎 기타
