### PR TITLE
출석 컴포넌트 정사각 비율 맞게 수정

### DIFF
--- a/src/components/AttendanceStatus/index.tsx
+++ b/src/components/AttendanceStatus/index.tsx
@@ -30,8 +30,7 @@ export function AttendanceStatus(props: UnCheckedProps) {
 const BaseStyled = styled.div`
   ${({ theme }) => theme.typo.caption};
 
-  width: 70px;
-  height: 70px;
+  aspect-ratio: 1 / 1;
   border-radius: 8px;
   display: flex;
   flex-direction: column;

--- a/src/features/home/Attendance/index.tsx
+++ b/src/features/home/Attendance/index.tsx
@@ -61,10 +61,7 @@ const Container = styled.div`
   }
 `;
 
-const Content = styled.div`
-  width: fit-content;
-  margin: 0 auto;
-`;
+const Content = styled.div``;
 
 const Title = styled.div`
   display: flex;
@@ -92,5 +89,4 @@ const Grid = styled.div`
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   grid-gap: 10px;
-  width: fit-content;
 `;


### PR DESCRIPTION
# 💡 기능
- 출석 컴포넌트를 정사각 비율이 맞도록 수정하였어요. 

# 🔎 기타
<img width="388" alt="스크린샷 2024-05-17 오후 8 38 46" src="https://github.com/depromeet/depromeet-makers-fe/assets/49177223/ad922e57-1aa5-44e3-9e12-f89472b6b92e">
<img width="476" alt="스크린샷 2024-05-17 오후 8 38 59" src="https://github.com/depromeet/depromeet-makers-fe/assets/49177223/6bc6072d-ebd8-4d08-beb2-4cbd905c93d8">
