### PR TITLE
세션 출석 상태 조회 API 연결

### DIFF
--- a/src/components/FAB/index.stories.tsx
+++ b/src/components/FAB/index.stories.tsx
@@ -14,7 +14,9 @@ export default meta;
 export const Default = () => {
   return (
     <FABWrapper>
-      <FAB text="플로팅 버튼 텍스트" subText="서브 텍스트" />
+      <FAB text="플로팅 버튼 텍스트" sessionAttendanceStatus="AFTER_15MINUTE" />
+      <FAB text="플로팅 버튼 텍스트" sessionAttendanceStatus="BEFORE_15MINUTE" />
+      <FAB text="플로팅 버튼 텍스트" sessionAttendanceStatus="ON_TIME" />
     </FABWrapper>
   );
 };

--- a/src/components/FAB/index.tsx
+++ b/src/components/FAB/index.tsx
@@ -1,30 +1,30 @@
 import type { ButtonHTMLAttributes } from 'react';
 import styled from 'styled-components';
 
-import { useCheckIn } from '@/hooks/apis/attendance/useCheckIn';
+import type { SessionAttendanceStatus } from '@/types/attendance';
 
 type FABProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   text: string;
-  subText?: string;
+  sessionAttendanceStatus: SessionAttendanceStatus;
 };
 
-export const FAB = ({ subText, text, children, ...props }: FABProps) => {
-  const { mutate } = useCheckIn();
+const SUB_TEXT = {
+  BEFORE_15MINUTE: '세션 시작 전 미리 출석해주세요!',
+  ON_TIME: '세션이 시작되었습니다.',
+  AFTER_15MINUTE: '출석 시 지각 처리됩니다.',
+};
 
-  const handleCheckIn = () => {
-    mutate();
-  };
-
+export const FAB = ({ text, sessionAttendanceStatus, children, ...props }: FABProps) => {
   return (
-    <FABStyled {...props} onClick={handleCheckIn}>
-      <SubText>{subText}</SubText>
+    <FABStyled sessionAttendanceStatus={sessionAttendanceStatus} {...props}>
+      <SubText>{SUB_TEXT[sessionAttendanceStatus]}</SubText>
       <Text>{text}</Text>
       {children}
     </FABStyled>
   );
 };
 
-const FABStyled = styled.button`
+const FABStyled = styled.button<Pick<FABProps, 'sessionAttendanceStatus'>>`
   position: fixed;
   left: 50%;
   bottom: 108px;
@@ -40,7 +40,8 @@ const FABStyled = styled.button`
   padding: 18px 32px;
 
   border-radius: 40px;
-  color: ${({ theme }) => theme.color.white};
+  color: ${({ theme, sessionAttendanceStatus }) =>
+    sessionAttendanceStatus === 'AFTER_15MINUTE' ? theme.color.yellow_300 : theme.color.white};
   background-color: ${({ theme }) => theme.color.gray_900};
 `;
 

--- a/src/components/FAB/index.tsx
+++ b/src/components/FAB/index.tsx
@@ -16,15 +16,15 @@ const SUB_TEXT = {
 
 export const FAB = ({ text, sessionAttendanceStatus, children, ...props }: FABProps) => {
   return (
-    <FABStyled sessionAttendanceStatus={sessionAttendanceStatus} {...props}>
-      <SubText>{SUB_TEXT[sessionAttendanceStatus]}</SubText>
+    <FABStyled {...props}>
+      <SubText sessionAttendanceStatus={sessionAttendanceStatus}>{SUB_TEXT[sessionAttendanceStatus]}</SubText>
       <Text>{text}</Text>
       {children}
     </FABStyled>
   );
 };
 
-const FABStyled = styled.button<Pick<FABProps, 'sessionAttendanceStatus'>>`
+const FABStyled = styled.button`
   position: fixed;
   left: 50%;
   bottom: 108px;
@@ -40,8 +40,7 @@ const FABStyled = styled.button<Pick<FABProps, 'sessionAttendanceStatus'>>`
   padding: 18px 32px;
 
   border-radius: 40px;
-  color: ${({ theme, sessionAttendanceStatus }) =>
-    sessionAttendanceStatus === 'AFTER_15MINUTE' ? theme.color.yellow_300 : theme.color.white};
+  color: ${({ theme }) => theme.color.white};
   background-color: ${({ theme }) => theme.color.gray_900};
 `;
 
@@ -50,7 +49,8 @@ const Text = styled.p`
   color: ${({ theme }) => theme.color.white};
 `;
 
-const SubText = styled.p`
+const SubText = styled.p<Pick<FABProps, 'sessionAttendanceStatus'>>`
   ${({ theme }) => theme.typo.caption};
-  color: ${({ theme }) => theme.color.gray_300};
+  color: ${({ theme, sessionAttendanceStatus }) =>
+    sessionAttendanceStatus === 'AFTER_15MINUTE' ? theme.color.yellow_300 : theme.color.gray_300};
 `;

--- a/src/hooks/apis/attendance/useGetCheckIn.ts
+++ b/src/hooks/apis/attendance/useGetCheckIn.ts
@@ -1,0 +1,26 @@
+import type { UseQueryOptions } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+
+import type { CustomError } from '@/apis';
+import { api } from '@/apis';
+import type { AttendanceStatus } from '@/types/attendance';
+
+interface CheckInResponse {
+  generation: number;
+  week: number;
+  isBeforeSession15minutes: boolean;
+  needFloatingButton: boolean;
+  expectAttendanceStatus: AttendanceStatus;
+}
+
+const POLLING_INTERVAL = 6000;
+
+export const useGetCheckIn = (options?: UseQueryOptions<CheckInResponse, CustomError>) => {
+  return useQuery({
+    queryKey: ['check-in'],
+    queryFn: () => api.get<CheckInResponse>(`/v1/check-in`),
+    ...options,
+    refetchInterval: POLLING_INTERVAL,
+    refetchIntervalInBackground: true,
+  });
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,16 +12,25 @@ import { Absence } from '@/features/home/Absence';
 import { Attendance } from '@/features/home/Attendance';
 import { RuleLink } from '@/features/home/RuleLink';
 import { useGetAttendance } from '@/hooks/apis/attendance/useGetAttendance';
+import { useGetCheckIn } from '@/hooks/apis/attendance/useGetCheckIn';
 import { useGetInfo } from '@/hooks/apis/user/useGetInfo';
 
 const Home = () => {
   const { data: attendance } = useGetAttendance({ generation: CURRENT_GENERATION });
+  const { data: sessionAttendance } = useGetCheckIn();
 
   // TODO: 응답 값으로 수정 필요
   const title = `디프만 15기 첫출발,\n함께 시작해 볼까요? 🌱`;
   const week = '1주차';
   const date = '4월 3일';
-  const isVisibleFab = true;
+  const isVisibleFab = sessionAttendance?.needFloatingButton;
+
+  const getSessionAttendanceStatus = () => {
+    if (sessionAttendance?.isBeforeSession15minutes) return 'BEFORE_15MINUTE';
+    if (sessionAttendance?.expectAttendanceStatus === 'ABSENCE') return 'AFTER_15MINUTE';
+
+    return 'ON_TIME';
+  };
 
   const router = useRouter();
 
@@ -57,7 +66,7 @@ const Home = () => {
         </AttendanceContainer>
       </Container>
 
-      {isVisibleFab && <FAB text="출석하기 🙌" subText="세션이 시작되었습니다." />}
+      {isVisibleFab && <FAB text="출석하기 🙌" sessionAttendanceStatus={getSessionAttendanceStatus()} />}
       <BottomNav items={USER_NAV_ITEMS} />
     </>
   );

--- a/src/types/attendance.d.ts
+++ b/src/types/attendance.d.ts
@@ -2,6 +2,8 @@ type AttendanceStatus = 'ATTENDANCE_ON_HOLD' | 'ATTENDANCE' | 'ABSENCE' | 'TARDY
 
 type SessionType = 'ONLINE' | 'OFFLINE';
 
+type SessionAttendanceStatus = 'BEFORE_15MINUTE' | 'ON_TIME' | 'AFTER_15MINUTE';
+
 export interface Attendance {
   attendanceId: string;
   generation: number;


### PR DESCRIPTION
# 💡 기능

- 세션 출석 상태 조회 api 추가 
   - 폴링 주기: 1분 

- 세션 출석 상태에 따라 플로팅 버튼 텍스트 및 스타일 수정  
<img width="373" alt="image" src="https://github.com/depromeet/depromeet-makers-fe/assets/80238096/dc9a0936-d3dd-46c5-beaa-f9c307b1c953">


# 🔎 기타

   - 세션 출석 상태 
        - 15분 전: 출석가능
        - 세션시작 ~ 15분 후: 출석가능
        - 세션15분 후 ~ 세션30분 후: 출석가능-지각처리
        - 세션30분 후:결석처리
     