### PR TITLE
input font-size 16px로 수정

### DIFF
--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -22,9 +22,9 @@ const InputStyled = styled.input<InputProps>`
   border-radius: 6px;
   line-height: 38px;
   ${({ theme }) => theme.typo.p};
+  font-size: 16px;
   border: 1px solid ${({ theme }) => theme.color.gray_300};
   outline: none;
-  /* outline: 1px solid ${({ theme }) => theme.color.gray_300}; */
   background: ${({ theme }) => theme.color.white};
   color: ${({ theme }) => theme.color.gray_900};
 


### PR DESCRIPTION
# 💡 기능
- IOS 에서 Input의 font-size가 16px 미만이면 자동으로 확대하는 현상이 있어 font-size를 수정하였습니다 (승희님의 컨펌 하에)
