### PR TITLE
출석 조회 리팩토링

### DIFF
--- a/src/hooks/apis/attendance/useCheckIn.ts
+++ b/src/hooks/apis/attendance/useCheckIn.ts
@@ -29,9 +29,9 @@ export const useCheckIn = (options?: UseMutationOptions<CheckInResponse, CustomE
     onSuccess: (data, ...rest) => {
       showSnackBar({ message: SNACKBAR_MESSAGE['200'] ?? data.message });
 
-      queryClient.invalidateQueries({ queryKey: ['check-in'] });
-
       options?.onSuccess?.(data, ...rest);
+
+      return queryClient.invalidateQueries({ queryKey: ['check-in'] });
     },
     onError: (data, ...rest) => {
       showSnackBar({ message: SNACKBAR_MESSAGE[data.code] ?? data.message });

--- a/src/hooks/apis/attendance/useGetCheckIn.ts
+++ b/src/hooks/apis/attendance/useGetCheckIn.ts
@@ -20,7 +20,7 @@ export const useGetCheckIn = (options?: UseQueryOptions<CheckInResponse, CustomE
     queryKey: ['check-in'],
     queryFn: () => api.get<CheckInResponse>(`/v1/check-in`),
     ...options,
-    refetchInterval: POLLING_INTERVAL,
+    refetchInterval: (data) => (data.state.error?.code ? 0 : POLLING_INTERVAL),
     refetchIntervalInBackground: true,
   });
 };

--- a/src/hooks/apis/attendance/useGetCheckIn.ts
+++ b/src/hooks/apis/attendance/useGetCheckIn.ts
@@ -22,5 +22,6 @@ export const useGetCheckIn = (options?: UseQueryOptions<CheckInResponse, CustomE
     ...options,
     refetchInterval: (data) => (data.state.error?.code ? 0 : POLLING_INTERVAL),
     refetchIntervalInBackground: true,
+    refetchOnMount: true,
   });
 };


### PR DESCRIPTION
# 💡 기능

- 출석 조회에서 api 에러 발생 시, 폴링하지 않도록 수정
- 출석 후에 출석 상태가 바로 반영될 수 있도록, `invalidateQueries` 수정

