### PR TITLE
로그인 후 계정 Role에 따라 리다이렉트 분기

### DIFF
--- a/src/features/login/CertifyStep.tsx
+++ b/src/features/login/CertifyStep.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
+import { useRouter } from 'next/router';
 
 import { usePostLogin } from '@/hooks/apis/auth/usePostLogin';
+import { getUserRoleByToken } from '@/hooks/apis/user/useGetInfo';
 
 import LoginLayout from './LoginLayout';
 import PasswordInput from './PasswordInput';
@@ -8,21 +10,25 @@ import PasswordInput from './PasswordInput';
 const PASSWORD_LENGTH = 6;
 
 interface Props {
-  onNext: () => void;
   onBack: () => void;
   email: string;
 }
 
 function CertifyStep(props: Props) {
+  const router = useRouter();
   const [value, setValue] = useState('');
-
   const [error, setError] = useState('');
 
   const isDisabled = value.length !== PASSWORD_LENGTH || Boolean(error);
 
   const { mutate } = usePostLogin({
-    onSuccess: () => {
-      props.onNext();
+    onSuccess: async ({ accessToken }) => {
+      const role = await getUserRoleByToken(accessToken);
+      if (role === 'ORGANIZER') {
+        router.replace('/admin/attendance');
+      } else {
+        router.replace('/');
+      }
     },
     onError: (error) => {
       setError(error.message);

--- a/src/features/login/JoinCompleteStep.tsx
+++ b/src/features/login/JoinCompleteStep.tsx
@@ -1,21 +1,31 @@
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import styled from 'styled-components';
+
+import { useGetInfo } from '@/hooks/apis/user/useGetInfo';
 
 import LoginLayout from './LoginLayout';
 import Img from './welcome-2.png';
 
-interface Props {
-  onNext: () => void;
-}
+function JoinCompleteStep() {
+  const router = useRouter();
+  const { data } = useGetInfo();
 
-function JoinCompleteStep(props: Props) {
+  const onNext = () => {
+    if (data?.generations[0].role === 'ORGANIZER') {
+      router.push('/admin/attendance');
+    } else {
+      router.push('/');
+    }
+  };
+
   return (
     <LoginLayout
       title="디프만 메이커스 가입 완료!"
       desc={`다시한번 디프만에 오신 걸 환영해요.\n지금 바로 디프만 메이커스를 사용해보세요.`}
       buttonProps={{
         children: '홈으로 바로가기',
-        onClick: props.onNext,
+        onClick: onNext,
       }}
     >
       <ImageContainer>

--- a/src/features/login/JoinCompleteStep.tsx
+++ b/src/features/login/JoinCompleteStep.tsx
@@ -13,9 +13,9 @@ function JoinCompleteStep() {
 
   const onNext = () => {
     if (data?.generations[0].role === 'ORGANIZER') {
-      router.push('/admin/attendance');
+      router.replace('/admin/attendance');
     } else {
-      router.push('/');
+      router.replace('/');
     }
   };
 

--- a/src/hooks/apis/auth/usePostLogin.ts
+++ b/src/hooks/apis/auth/usePostLogin.ts
@@ -24,10 +24,10 @@ export const usePostLogin = (options?: UseMutationOptions<PostLoginResponse, Cus
   useMutation({
     mutationFn: postLogin,
     ...options,
-    onSuccess: (data, ...rest) => {
+    onSuccess: async (data, ...rest) => {
       Cookies.set(COOKIE_KEY.ACCESS_TOKEN, data.accessToken, { expires: 1 });
       Cookies.set(COOKIE_KEY.REFRESH_TOKEN, data.refreshToken, { expires: 7 });
 
-      options?.onSuccess?.(data, ...rest);
+      options?.onSuccess?.({ ...data }, ...rest);
     },
   });

--- a/src/hooks/apis/user/useGetInfo.ts
+++ b/src/hooks/apis/user/useGetInfo.ts
@@ -4,24 +4,38 @@ import { useQuery } from '@tanstack/react-query';
 import type { CustomError } from '@/apis';
 import { api } from '@/apis';
 
+type Role = 'ORGANIZER' | 'MEMBER';
+
 interface GetInfoResponse {
   id: string;
   name: string;
   email: string;
   generations: {
     generationId: number;
-    role: string;
+    role: Role;
     position: string;
   }[];
 }
 
-const getInfo = async (): Promise<GetInfoResponse> => {
-  return await api.get<GetInfoResponse>('/v1/me');
+export const getInfoByToken = async (token: string): Promise<GetInfoResponse> => {
+  return await api.get<GetInfoResponse>('/v1/me', {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
 };
+
+export const getUserRoleByToken = async (token: string): Promise<Role> => {
+  const { generations } = await getInfoByToken(token);
+
+  return generations[0].role;
+};
+
+const getInfo = () => api.get<GetInfoResponse>('/v1/me');
 
 export const useGetInfo = (options?: UseQueryOptions<GetInfoResponse, CustomError>) =>
   useQuery({
     queryKey: ['me'],
-    queryFn: getInfo,
+    queryFn: () => getInfo(),
     ...options,
   });

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import type { GetServerSideProps } from 'next';
-import { useRouter } from 'next/router';
 
 import { Metadata } from '@/components/Metadata';
 import { COOKIE_KEY } from '@/constants/cookie';
@@ -38,15 +37,9 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 };
 
 function LoginPage() {
-  const router = useRouter();
-
   const { Funnel, Step, setStep } = useFunnel(STEP.WELCOME);
 
   const [email, setEmail] = useState('');
-
-  const handleCompleteSignUp = () => {
-    router.push('/');
-  };
 
   return (
     <div>
@@ -69,10 +62,10 @@ function LoginPage() {
           <JoinStep email={email} onBack={() => setStep(STEP.EMAIL)} onNext={() => setStep(STEP.JOIN_COMPLETE)} />
         </Step>
         <Step name={STEP.JOIN_COMPLETE}>
-          <JoinCompleteStep onNext={handleCompleteSignUp} />
+          <JoinCompleteStep />
         </Step>
         <Step name={STEP.CERTIFY}>
-          <CertifyStep email={email} onNext={handleCompleteSignUp} onBack={() => setStep(STEP.EMAIL)} />
+          <CertifyStep email={email} onBack={() => setStep(STEP.EMAIL)} />
         </Step>
       </Funnel>
     </div>


### PR DESCRIPTION
# 💡 기능
- 로그인 성공 후 해당 계정 role에 따라 이동할 페이지를 결정 후 리다이렉트
- 로그인페이지 다시 접근 못하게 replace로 이동