### PR TITLE
feat: 어드민 출석 현황에서 해당 주차뷰가 바로 보이도록 수정

### DIFF
--- a/src/hooks/useCurrentWeek.ts
+++ b/src/hooks/useCurrentWeek.ts
@@ -1,0 +1,14 @@
+import { useState } from 'react';
+
+import { useGetSession } from './apis/sessions/useGetSession';
+
+export const useCurrentWeek = () => {
+  const [week, setWeek] = useState<number | null>(null);
+
+  const { data: session } = useGetSession();
+
+  return {
+    week: week ?? (session?.week || 1),
+    setWeek,
+  };
+};

--- a/src/pages/admin/attendance.tsx
+++ b/src/pages/admin/attendance.tsx
@@ -11,11 +11,13 @@ import TeamSelect from '@/features/admin/attendance/TeamSelect';
 import UserItem from '@/features/admin/attendance/UserItem';
 import WeekSelect from '@/features/admin/attendance/WeekSelect';
 import { useGetGroupAttendance } from '@/hooks/apis/attendance/useGetGroupAttendance';
+import { useCurrentWeek } from '@/hooks/useCurrentWeek';
 
 function AdminAttendancePage() {
   const { ref, isViewMiniHeader } = useScrollAction();
 
-  const [week, setWeek] = useState(1);
+  const { week, setWeek } = useCurrentWeek();
+
   const [team, setTeam] = useState(1);
 
   const { data } = useGetGroupAttendance({ generation: 15, week, groupId: String(team) });
@@ -43,7 +45,9 @@ function AdminAttendancePage() {
             </TeamSection>
           </>
         )}
-        <UserSection ref={ref}>{data?.map((data) => <UserItem key={data.memberId} {...data} />)}</UserSection>
+        <UserSection ref={ref}>
+          {data?.map((data) => <UserItem key={`${data.memberId}-${data.week}`} {...data} />)}
+        </UserSection>
       </Main>
       <BottomNav items={ADMIN_NAV_ITEMS} />
     </Layout>


### PR DESCRIPTION
# 💡 기능

- 어드민 출석 현황에서 해당 주차뷰가 바로 보이도록 수정
  - as-is: 무조건 1주차가 보여서 불편한 UX 
  - to-be: 해당 주차로 보이도록 수정 

# 🔎 기타
