### PR TITLE
fix: 일반 멤버인 경우 세션 위치 정보 내 위도, 경도 마스킹 처리 추가 반영

### DIFF
--- a/src/features/schedule/ScheduleItem/LocationButton.tsx
+++ b/src/features/schedule/ScheduleItem/LocationButton.tsx
@@ -9,11 +9,10 @@ type LocationButtonProps = Pick<SessionType, 'place'>;
 export const LocationButton = ({ place }: LocationButtonProps) => {
   if (!place) return null;
 
-  const { address, latitude, longitude } = place;
+  const { address } = place;
 
   if (address === '온라인') return null;
-
-  if (latitude === 0 || longitude === 0) return null;
+  if (address === '오프라인') return null;
 
   const handleClickLocationButton = () => {
     openKakaoMap(place);


### PR DESCRIPTION
# 💡 기능

- 일반 멤버인 경우 세션 위치 정보 내 위도, 경도가 (0, 0)
- 오프라인 장소가 미정인 경우, 지도 버튼이 보이지 않도록 수정

# 🔎 기타
