### PR TITLE
feat: 출석 코드 모달 ui 추가

### DIFF
--- a/src/components/Modal/index.stories.tsx
+++ b/src/components/Modal/index.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Modal } from '.';
+
+const meta: Meta<typeof Modal> = {
+  title: 'Modal',
+  component: Modal,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Modal>;
+
+export const Default: Story = {
+  args: {
+    isOpen: true,
+  },
+};

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,0 +1,65 @@
+import type { ComponentProps, PropsWithChildren } from 'react';
+import type { AnimatePresence } from 'framer-motion';
+import styled from 'styled-components';
+
+import Icon from '../Icon';
+import AnimatePortal from '../Portal/AnimatePortal';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  mode?: ComponentProps<typeof AnimatePresence>['mode'];
+}
+
+export const Modal = ({ isOpen, onClose, mode = 'wait', children }: PropsWithChildren<ModalProps>) => {
+  return (
+    <AnimatePortal isShowing={isOpen} mode={mode}>
+      <Overlay onClick={onClose}>
+        <Content>
+          <Header>
+            <CloseButton type="button" onClick={onClose}>
+              <Icon name="x-icon" />
+            </CloseButton>
+          </Header>
+          {children}
+        </Content>
+      </Overlay>
+    </AnimatePortal>
+  );
+};
+
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  background-color: rgba(0, 0, 0, 0.8);
+`;
+
+const Header = styled.div`
+  display: flex;
+  padding: 16px;
+  gap: 10px;
+`;
+
+const Content = styled.div`
+  position: relative;
+  width: 351px;
+  max-width: 100%;
+
+  padding: 20px;
+  border-radius: 12px;
+  background-color: ${({ theme }) => theme.color.white};
+`;
+
+const CloseButton = styled.button`
+  position: absolute;
+  top: 16px;
+  right: 16px;
+`;

--- a/src/features/home/AttendanceCodeModal/CodeInputs.tsx
+++ b/src/features/home/AttendanceCodeModal/CodeInputs.tsx
@@ -1,0 +1,50 @@
+import type { ChangeEvent, MutableRefObject } from 'react';
+import styled from 'styled-components';
+
+interface CodeInputsProps {
+  inputRefs: MutableRefObject<(HTMLInputElement | null)[]>;
+  onChange: (e: ChangeEvent<HTMLInputElement>, index: number) => void;
+  onFocus: (index: number) => () => void;
+}
+
+export const CodeInputs = ({ inputRefs, onChange, onFocus }: CodeInputsProps) => {
+  return (
+    <InputContainer>
+      {Array.from({ length: 4 }).map((_, index) => (
+        <Input
+          autoFocus={index === 0}
+          key={index}
+          type="number"
+          ref={(element) => (inputRefs.current[index] = element)}
+          onChange={(event) => onChange(event, index)}
+          onFocus={onFocus(index)}
+          maxLength={1}
+          placeholder="*"
+        />
+      ))}
+    </InputContainer>
+  );
+};
+
+const InputContainer = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-bottom: 20px;
+`;
+
+const Input = styled.input<{ ref: (element: HTMLInputElement | null) => void }>`
+  width: 57px;
+  height: 70px;
+  padding: 10px;
+
+  ${({ theme }) => theme.typo.title3};
+  text-align: center;
+  caret-color: transparent;
+
+  border-radius: 6px;
+  background-color: ${({ theme }) => theme.color.gray_100};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.color.gray_300};
+  }
+`;

--- a/src/features/home/AttendanceCodeModal/index.stories.tsx
+++ b/src/features/home/AttendanceCodeModal/index.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta } from '@storybook/react';
+
+import { AttendanceCodeModal } from '.';
+
+const meta: Meta<typeof AttendanceCodeModal> = {
+  title: 'home/AttendanceCodeModal',
+  component: AttendanceCodeModal,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+export const Default = () => {
+  return <AttendanceCodeModal />;
+};

--- a/src/features/home/AttendanceCodeModal/index.tsx
+++ b/src/features/home/AttendanceCodeModal/index.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent, FormEvent } from 'react';
-import { useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import Button from '@/components/Button';
@@ -9,13 +9,21 @@ import { CodeInputs } from './CodeInputs';
 
 export const AttendanceCodeModal = () => {
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const [inputs, setInputs] = useState<string[]>(['', '', '', '']);
+
   // TODO: api 추가 후 에러 처리 필요
   const isError = true;
+
+  const isDisabledSubmit = useMemo(() => inputs.some((input) => input === ''), [inputs]);
 
   const handleAutoFocusNextInput = (event: ChangeEvent<HTMLInputElement>, index: number) => {
     const { maxLength, value } = event.target;
 
     if (value.length > maxLength) return;
+
+    const newInputs = [...inputs];
+    newInputs[index] = value;
+    setInputs(newInputs);
 
     const currentInput = inputRefs.current[index];
     const nextInput = inputRefs.current[index + 1];
@@ -30,11 +38,15 @@ export const AttendanceCodeModal = () => {
   };
 
   const handleClearNextAllInputs = (currentIndex: number) => () => {
-    inputRefs.current.forEach((input, index) => {
+    const inputs = inputRefs.current.map((input, index) => {
       if (input && index >= currentIndex) {
         input.value = '';
+        return '';
       }
+      return input?.value ?? '';
     });
+
+    setInputs(inputs);
   };
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -52,7 +64,9 @@ export const AttendanceCodeModal = () => {
         <Text>출석 코드를 입력해주세요</Text>
         <CodeInputs inputRefs={inputRefs} onChange={handleAutoFocusNextInput} onFocus={handleClearNextAllInputs} />
         {isError && <ErrorMessage>본 세션에 해당하는 출석 코드가 아닙니다. 다시 입력해주세요.</ErrorMessage>}
-        <SubmitButton type="submit">확인</SubmitButton>
+        <SubmitButton type="submit" disabled={isDisabledSubmit}>
+          확인
+        </SubmitButton>
       </Form>
     </Modal>
   );

--- a/src/features/home/AttendanceCodeModal/index.tsx
+++ b/src/features/home/AttendanceCodeModal/index.tsx
@@ -1,0 +1,82 @@
+import type { ChangeEvent, FormEvent } from 'react';
+import { useRef } from 'react';
+import styled from 'styled-components';
+
+import Button from '@/components/Button';
+import { Modal } from '@/components/Modal';
+
+import { CodeInputs } from './CodeInputs';
+
+export const AttendanceCodeModal = () => {
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+  // TODO: api 추가 후 에러 처리 필요
+  const isError = true;
+
+  const handleAutoFocusNextInput = (event: ChangeEvent<HTMLInputElement>, index: number) => {
+    const { maxLength, value } = event.target;
+
+    if (value.length > maxLength) return;
+
+    const currentInput = inputRefs.current[index];
+    const nextInput = inputRefs.current[index + 1];
+
+    // 마지막 input이거나 다음 input 값이 있으면 blur
+    if (!nextInput || nextInput.value) {
+      currentInput?.blur();
+      return;
+    }
+
+    nextInput.focus();
+  };
+
+  const handleClearNextAllInputs = (currentIndex: number) => () => {
+    inputRefs.current.forEach((input, index) => {
+      if (input && index >= currentIndex) {
+        input.value = '';
+      }
+    });
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const code = inputRefs.current.map((input) => input?.value || '').join('');
+
+    // TODO: api 추가 예정
+    console.log(code);
+  };
+
+  return (
+    <Modal isOpen onClose={() => {}}>
+      <Form onSubmit={handleSubmit}>
+        <Text>출석 코드를 입력해주세요</Text>
+        <CodeInputs inputRefs={inputRefs} onChange={handleAutoFocusNextInput} onFocus={handleClearNextAllInputs} />
+        {isError && <ErrorMessage>본 세션에 해당하는 출석 코드가 아닙니다. 다시 입력해주세요.</ErrorMessage>}
+        <SubmitButton type="submit">확인</SubmitButton>
+      </Form>
+    </Modal>
+  );
+};
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Text = styled.p`
+  ${({ theme }) => theme.typo.h3};
+
+  margin-bottom: 32px;
+`;
+
+const SubmitButton = styled(Button)`
+  width: 100%;
+  margin-top: 12px;
+`;
+
+const ErrorMessage = styled.p`
+  ${({ theme }) => theme.typo.caption};
+  color: ${({ theme }) => theme.color.red_300};
+`;

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -31,6 +31,28 @@ const GlobalStyle = createGlobalStyle`
     padding: 0;
     cursor: pointer;
   }
+
+  input {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    border: none;
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  input::-ms-clear { 
+    display: none; 
+  }
+
+  input[type='number']::-webkit-inner-spin-button,
+  input[type='number']::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+  }
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
# 💡 기능

- Modal 컴포넌트 추가
- 출석코드 Modal 컴포넌트 추가
   -  다음 input으로 자동 포커스 
   - 값이 있는 input을 누르면 이후의 input들은 다 비워짐

# 🔎 기타
<img width="385" alt="스크린샷 2024-07-18 오후 9 10 39" src="https://github.com/user-attachments/assets/55e4ac9b-1207-47ae-bca3-8340c4fb8110">

- UX가 따로 잡힌게 없어서 .. 제가 임의로 추가했는데 더 좋은 UX 있으면 의견 많 부
