### PR TITLE
페이지 접근 제어 

### DIFF
--- a/src/hooks/apis/user/useGetInfo.ts
+++ b/src/hooks/apis/user/useGetInfo.ts
@@ -6,7 +6,7 @@ import { api } from '@/apis';
 
 type Role = 'ORGANIZER' | 'MEMBER';
 
-interface GetInfoResponse {
+export interface GetInfoResponse {
   id: string;
   name: string;
   email: string;

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,0 +1,12 @@
+export default function AdminPage() {
+  return <></>;
+}
+
+export const getServerSideProps = () => {
+  return {
+    redirect: {
+      destination: '/admin/attendance',
+      permanent: false,
+    },
+  };
+};


### PR DESCRIPTION
# 💡 기능
- admin, member에 따라 접근할 수 있는 페이지 컨트롤이 되고 있지 않아서 추가했습니다. 
- 기존에는 admin도 member 페이지에 접근할 수 있어서 그랬던것 같아요. 
- 앱으로 변경되며 url을 조작할 수 없음 -> admin은 어드민 페이지만, member은 member 페이지만 접근되도록 하였습니다. 