### PR TITLE
fix: 메인 페이지에서 주차 업데이트 안되는 이슈 수정

### DIFF
--- a/src/hooks/apis/sessions/useGetSession.ts
+++ b/src/hooks/apis/sessions/useGetSession.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import type { CustomError } from '@/apis';
 import { api } from '@/apis';
+import { CURRENT_GENERATION } from '@/constants/attendance';
 
 interface GetSessionRequest {
   generation: number;
@@ -15,16 +16,16 @@ interface GetSessionResponse {
   code: string;
 }
 
-export const fetchSessionList = async (): Promise<GetSessionResponse> => {
-  const generation = process.env.NEXT_PUBLIC_DEPROMEET_GENERATION;
-  const request: GetSessionRequest = { generation: Number(generation) };
-
-  return await api.get<GetSessionResponse>('/v1/sessions/info', { params: request });
+export const fetchSessionList = (params: GetSessionRequest) => {
+  return api.get<GetSessionResponse>('/v1/sessions/info', { params });
 };
 
-export const useGetSession = (options?: UseQueryOptions<GetSessionResponse, CustomError, GetSessionResponse>) =>
+export const useGetSession = (
+  params: GetSessionRequest = { generation: CURRENT_GENERATION },
+  options?: UseQueryOptions<GetSessionResponse, CustomError, GetSessionResponse>,
+) =>
   useQuery({
-    queryKey: ['session'],
-    queryFn: () => fetchSessionList(),
+    queryKey: ['session', params.generation],
+    queryFn: () => fetchSessionList(params),
     ...options,
   });

--- a/src/pages/admin/attendance.tsx
+++ b/src/pages/admin/attendance.tsx
@@ -82,7 +82,10 @@ export const getStaticProps: GetStaticProps = async () => {
         queryKey: ['attendances-group'],
         queryFn: () => fetchGroupAttendace({ generation: CURRENT_GENERATION, week: 1, groupId: '1' }),
       }),
-      queryClient.prefetchQuery({ queryKey: ['session'], queryFn: () => fetchSessionList() }),
+      queryClient.prefetchQuery({
+        queryKey: ['session'],
+        queryFn: () => fetchSessionList({ generation: CURRENT_GENERATION }),
+      }),
     ]);
 
     queryClient.setQueryData(['attendances-group'], (groupAttendance as unknown) ?? []);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -95,8 +95,11 @@ export const getStaticProps: GetStaticProps = async () => {
         queryKey: ['attendances-me'],
         queryFn: () => fetchAttendance({ generation: CURRENT_GENERATION }),
       }),
-      queryClient.prefetchQuery({ queryKey: ['session'], queryFn: () => fetchSessionList }),
-      queryClient.prefetchQuery({ queryKey: ['me'], queryFn: () => fetchInfo }),
+      queryClient.prefetchQuery({
+        queryKey: ['session'],
+        queryFn: () => fetchSessionList({ generation: CURRENT_GENERATION }),
+      }),
+      queryClient.prefetchQuery({ queryKey: ['me'], queryFn: () => fetchInfo() }),
     ]);
 
     queryClient.setQueryData(['attendances-me'], (attendance as unknown) ?? {});


### PR DESCRIPTION
# 💡 기능

- 메인 페이지에서 계속 1주차로 보이는 이슈를 수정했습니다.
- 쿼리키를 추가하여 prefetch 이후에도 업데이트가 될 수 있도록 수정했습니다.

# 🔎 기타
