### PR TITLE
refactor: 비밀번호 입력란 UX 수정

### DIFF
--- a/apps/web/src/features/login/PasswordInput.tsx
+++ b/apps/web/src/features/login/PasswordInput.tsx
@@ -1,3 +1,4 @@
+import type { ChangeEvent } from 'react';
 import { useRef } from 'react';
 import styled from 'styled-components';
 
@@ -18,13 +19,27 @@ function PasswordInput(props: Props) {
     inputRef.current.focus();
   };
 
+  const handleChangePassword = (event: ChangeEvent<HTMLInputElement>) => {
+    const input = event.target.value;
+    const { passwordLength, onChange } = props;
+
+    const validInput = input.slice(0, passwordLength);
+
+    if (inputRef.current) {
+      inputRef.current.value = validInput;
+    }
+
+    onChange(validInput);
+  };
+
   return (
     <DotContainer>
       <Input
+        ref={inputRef}
         autoFocus
         type="number"
         maxLength={props.passwordLength}
-        onChange={(e) => e.target.value.length <= props.passwordLength && props.onChange(e.target.value)}
+        onChange={handleChangePassword}
         onBlur={handleBlur}
       />
       {Array.from({ length: props.passwordLength }, (_, index) => (


### PR DESCRIPTION
# 💡 기능

<img src="https://github.com/user-attachments/assets/7beda3b0-03f6-46c1-a6c2-537c77658ef0" width="300px" />

 비밀번호 입력 안되는 버그처럼 보이는 UX에 대해 수정했습니다.

- [x] 비밀번호 입력란 포커스 나가지 않도록 수정 
  - blur로 포커스가 나가도 다시 포커스를 넣도록 수정   

- [x] 비밀번호 길이 6글자만 입력되도록 제한 
  - 6글자 초과로 입력 가능하지만 UI 상으로만 노출이 안되고 있음 

# 🔎 기타
