### PR TITLE
feat:admin prefetch 및 HydrationBoundary를 통한 초기 데이터 로딩 최적화

### DIFF
--- a/apps/admin/src/app/(admin)/session/(component)/session-table-skeleton.tsx
+++ b/apps/admin/src/app/(admin)/session/(component)/session-table-skeleton.tsx
@@ -1,0 +1,35 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+
+const COLUMN_COUNT = 5;
+const ROW_COUNT = 10;
+
+export const SessionTableSkeleton = () => {
+  return (
+    <div className="space-y-4">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>주차</TableHead>
+            <TableHead>세션 종류</TableHead>
+            <TableHead>세션 이름</TableHead>
+            <TableHead>시작 시간</TableHead>
+            <TableHead>세션 장소</TableHead>
+          </TableRow>
+        </TableHeader>
+
+        <TableBody>
+          {Array.from({ length: ROW_COUNT }).map((_, rowIndex) => (
+            <TableRow key={rowIndex}>
+              {Array.from({ length: COLUMN_COUNT }).map((_, colIndex) => (
+                <TableCell key={colIndex} className="p-4">
+                  <Skeleton className="h-4 w-full rounded-lg" />
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};

--- a/apps/admin/src/app/(admin)/session/page.tsx
+++ b/apps/admin/src/app/(admin)/session/page.tsx
@@ -1,8 +1,13 @@
+import { Suspense } from 'react';
 import Link from 'next/link';
+import { getSuspenseSessionListOption } from '@depromeet-makers/api';
 
 import { SessionTable } from '@/components/session/SessionTable';
 import { Button } from '@/components/ui/button';
 import { H4 } from '@/components/ui/typography';
+import { PrefetchBoundary } from '@/context/PrefetchBoundary';
+
+import { SessionTableSkeleton } from './(component)/session-table-skeleton';
 
 const SessionPage = () => {
   return (
@@ -14,7 +19,11 @@ const SessionPage = () => {
         </Link>
       </div>
 
-      <SessionTable />
+      <Suspense fallback={<SessionTableSkeleton />}>
+        <PrefetchBoundary prefetchOptions={getSuspenseSessionListOption()}>
+          <SessionTable />
+        </PrefetchBoundary>
+      </Suspense>
     </div>
   );
 };

--- a/apps/admin/src/context/PrefetchBoundary.tsx
+++ b/apps/admin/src/context/PrefetchBoundary.tsx
@@ -1,0 +1,35 @@
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+
+import {
+  isPrefetchInfiniteOptions,
+  isPrefetchOptions,
+  type PrefetchInfiniteOptions,
+  type PrefetchOptions,
+} from './type';
+
+interface PrefetchBoundaryProps {
+  prefetchOptions: PrefetchOptions[] | PrefetchInfiniteOptions[] | PrefetchOptions | PrefetchInfiniteOptions;
+  children: React.ReactNode;
+}
+
+export const PrefetchBoundary = async ({ prefetchOptions, children }: PrefetchBoundaryProps) => {
+  const queryClient = new QueryClient();
+
+  const prefetch = async (option: PrefetchOptions | PrefetchInfiniteOptions) => {
+    if (isPrefetchOptions(option)) {
+      return queryClient.prefetchQuery(option);
+    }
+
+    if (isPrefetchInfiniteOptions(option)) {
+      return queryClient.prefetchInfiniteQuery(option);
+    }
+  };
+
+  const prefetchAll = async (options: PrefetchOptions[] | PrefetchInfiniteOptions[]) => {
+    return Promise.all(options.map(prefetch));
+  };
+
+  Array.isArray(prefetchOptions) ? await prefetchAll(prefetchOptions) : await prefetch(prefetchOptions);
+
+  return <HydrationBoundary state={dehydrate(queryClient)}>{children}</HydrationBoundary>;
+};

--- a/apps/admin/src/context/type.ts
+++ b/apps/admin/src/context/type.ts
@@ -1,0 +1,32 @@
+import type {
+  FetchInfiniteQueryOptions,
+  FetchQueryOptions,
+  UseInfiniteQueryOptions,
+  UseQueryOptions,
+  UseSuspenseInfiniteQueryOptions,
+  UseSuspenseQueryOptions,
+} from '@tanstack/react-query';
+
+export type PrefetchOptions = Pick<FetchQueryOptions, 'queryKey' | 'queryFn'>;
+export type PrefetchInfiniteOptions = Pick<FetchInfiniteQueryOptions, 'queryKey' | 'queryFn' | 'initialPageParam'>;
+
+export const isPrefetchOptions = (option: PrefetchOptions | PrefetchInfiniteOptions): option is FetchQueryOptions => {
+  return 'queryKey' in option && 'queryFn' in option && !('initialPageParam' in option);
+};
+
+export const isPrefetchInfiniteOptions = (
+  option: PrefetchOptions | PrefetchInfiniteOptions,
+): option is FetchInfiniteQueryOptions => {
+  return 'queryKey' in option && 'queryFn' in option && 'initialPageParam' in option;
+};
+
+export type BasicSuspenseQueryOptions<T> = Pick<UseSuspenseQueryOptions<T>, 'queryKey' | 'queryFn'>;
+export type BasicQueryOptions<T> = Pick<UseQueryOptions<T>, 'queryKey' | 'queryFn'>;
+export type BasicInfiniteQueryOptions<T> = Pick<
+  UseInfiniteQueryOptions<T>,
+  'queryKey' | 'queryFn' | 'initialPageParam'
+>;
+export type BasicSuspenseInifniteQueryOptions<T> = Pick<
+  UseSuspenseInfiniteQueryOptions<T>,
+  'queryKey' | 'queryFn' | 'initialPageParam'
+>;

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,9 +3,13 @@
   "version": "0.0.0",
   "type": "module",
   "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "dependencies": {
     "@tanstack/react-query": "^5.32.0",
-    "axios": "^1.6.8"
+    "axios": "^1.6.8",
+    "next": "14.2.3"
   },
   "devDependencies": {
     "@depromeet-makers/constant": "workspace:*",

--- a/packages/api/src/base/httpClient.ts
+++ b/packages/api/src/base/httpClient.ts
@@ -1,4 +1,3 @@
-import { COOKIE_KEY } from '@depromeet-makers/constant';
 import axios, {
   type AxiosError,
   type AxiosInstance,
@@ -7,7 +6,8 @@ import axios, {
   type InternalAxiosRequestConfig,
   isAxiosError,
 } from 'axios';
-import Cookies from 'js-cookie';
+
+import { getToken } from './token';
 
 class HttpClient {
   private client: AxiosInstance;
@@ -43,8 +43,8 @@ class HttpClient {
     this.client.interceptors.response.use(this.onResponseFulfilled, this.onResponseRejected);
   }
 
-  private onRequestFulfilled(config: InternalAxiosRequestConfig) {
-    const token = Cookies.get(COOKIE_KEY.ACCESS_TOKEN);
+  private async onRequestFulfilled(config: InternalAxiosRequestConfig) {
+    const token = await getToken();
 
     if (token) {
       config.headers['Authorization'] = `Bearer ${token}`;

--- a/packages/api/src/base/token.ts
+++ b/packages/api/src/base/token.ts
@@ -1,0 +1,65 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { COOKIE_KEY } from '@depromeet-makers/constant';
+import Cookies from 'js-cookie';
+
+const isClientSide = typeof window !== 'undefined';
+
+/**
+ * 인증 토큰을 쿠키와 클라이언트 환경에 저장합니다.
+ *
+ * @param token 저장할 인증 토큰
+ * @returns 저장된 토큰
+ */
+export const setToken = async (token: string) => {
+  const cookieStore = await cookies();
+  const serverToken = cookieStore.get(COOKIE_KEY.ACCESS_TOKEN)?.value;
+
+  if (serverToken) {
+    cookieStore.set(COOKIE_KEY.ACCESS_TOKEN, serverToken);
+  }
+
+  if (isClientSide) {
+    Cookies.set(COOKIE_KEY.ACCESS_TOKEN, token);
+  }
+
+  return token;
+};
+
+/**
+ * 저장된 인증 토큰을 가져옵니다.
+ * 서버 쿠키를 우선 확인하고, 없으면 클라이언트 쿠키를 확인합니다.
+ *
+ * @returns 저장된 토큰 또는 빈 문자열
+ */
+export const getToken = async () => {
+  const cookieStore = await cookies();
+  const serverToken = cookieStore.get(COOKIE_KEY.ACCESS_TOKEN)?.value;
+
+  if (serverToken) return serverToken;
+
+  if (isClientSide) {
+    const clientToken = Cookies.get(COOKIE_KEY.ACCESS_TOKEN);
+
+    if (clientToken) {
+      setToken(clientToken);
+      return clientToken;
+    }
+  }
+
+  return '';
+};
+
+/**
+ * 저장된 인증 토큰 제거
+ */
+export const removeToken = async () => {
+  const cookieStore = await cookies();
+
+  cookieStore.delete(COOKIE_KEY.ACCESS_TOKEN);
+
+  if (isClientSide) {
+    Cookies.remove(COOKIE_KEY.ACCESS_TOKEN);
+  }
+};

--- a/packages/api/src/base/token.ts
+++ b/packages/api/src/base/token.ts
@@ -14,11 +14,8 @@ const isClientSide = typeof window !== 'undefined';
  */
 export const setToken = async (token: string) => {
   const cookieStore = await cookies();
-  const serverToken = cookieStore.get(COOKIE_KEY.ACCESS_TOKEN)?.value;
 
-  if (serverToken) {
-    cookieStore.set(COOKIE_KEY.ACCESS_TOKEN, serverToken);
-  }
+  cookieStore.set(COOKIE_KEY.ACCESS_TOKEN, token);
 
   if (isClientSide) {
     Cookies.set(COOKIE_KEY.ACCESS_TOKEN, token);

--- a/packages/api/src/sessions/useGetSessionList.ts
+++ b/packages/api/src/sessions/useGetSessionList.ts
@@ -1,5 +1,5 @@
 import type { UseQueryOptions } from '@tanstack/react-query';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import type { CustomError } from '../base';
 import { api } from '../base';
@@ -21,11 +21,31 @@ export const getSessionList = async (): Promise<GetSessionListResponse> => {
   return await api.get<GetSessionListResponse>('/v1/sessions', { params: request });
 };
 
+export const getSuspenseSessionList = async (): Promise<GetSessionListResponse> => {
+  const generation = process.env.NEXT_PUBLIC_DEPROMEET_GENERATION;
+  const request: GetSessionListRequest = { generation: Number(generation) };
+
+  return await api.get<GetSessionListResponse>('/v1/sessions', { params: request });
+};
+
+export const getSuspenseSessionListOption = () => ({
+  queryKey: ['sessions'],
+  queryFn: () => getSuspenseSessionList(),
+});
+
 export const useGetSessionList = (
   options?: UseQueryOptions<GetSessionListResponse, CustomError, GetSessionListResponse>,
 ) =>
   useQuery({
     queryKey: ['sessions'],
     queryFn: () => getSessionList(),
+    ...options,
+  });
+
+export const useGetSuspenseSessionList = (
+  options?: UseQueryOptions<GetSessionListResponse, CustomError, GetSessionListResponse>,
+) =>
+  useSuspenseQuery({
+    ...getSuspenseSessionListOption(),
     ...options,
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,9 @@ importers:
       axios:
         specifier: ^1.6.8
         version: 1.7.2
+      next:
+        specifier: 14.2.3
+        version: 14.2.3(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@depromeet-makers/constant':
         specifier: workspace:*


### PR DESCRIPTION
# 💡 기능

- 서버 컴포넌트에서 prefetch를 통해 초기 데이터 넘겨주는 방식으로 구현
    1.  서버 컴포넌트에서 query client를 통해 데이터를 `prefetch`
    2. HydrationBoundary를 사용하여 query client를 `dehydrate` 
    3. 클라이언트로 query client 객체를 내려준다.

### Example

``` tsx
<Suspense fallback={<Loading />}>
 <PrefetchBoundary ...> // prefetchQuery 실행
   <Component /> // useSuspenseQuery 실행 (서버 액션)
 </PrefetchBoundary>
</Suspense>
```

# 🔎 기타

- Reference
   - [TanStack Query Advanced SSR 가이드](https://tanstack.com/query/latest/docs/framework/react/guides/advanced-ssr)
- 추후에는 [Experimental streaming without prefetching in Next.js](https://tanstack.com/query/latest/docs/framework/react/guides/advanced-ssr#experimental-streaming-without-prefetching-in-nextjs) 이 방식이 stable된다면 리팩토링해봐도 좋을 것 같음