### PR TITLE
feat:admin 세션 장소 카카오맵 검색 기능 추가

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -39,6 +39,7 @@
     "react-day-picker": "8.10.1",
     "react-dom": "^18",
     "react-hook-form": "^7.54.2",
+    "react-kakao-maps-sdk": "^1.1.27",
     "sonner": "^1.7.4",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",

--- a/apps/admin/src/app/(admin)/session/(component)/kakao-map-form.tsx
+++ b/apps/admin/src/app/(admin)/session/(component)/kakao-map-form.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import type { ControllerRenderProps, FieldPath, FieldValues } from 'react-hook-form';
+import { Map, MapMarker, useKakaoLoader } from 'react-kakao-maps-sdk';
+
+import { Skeleton } from '@/components/ui/skeleton';
+
+import type { MarkerType } from '../(context)/kakao-map-context';
+import { useKaKaoMap } from '../(context)/kakao-map-context';
+
+import { KaKaoMapSearch } from './kakao-map-search';
+
+interface KaKaoMapFormProps<T extends FieldValues = FieldValues> extends ControllerRenderProps<T, FieldPath<T>> {}
+
+export const KaKaoMapForm = ({ onChange }: KaKaoMapFormProps) => {
+  const [loading, error] = useKakaoLoader({
+    appkey: process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY ?? '',
+    libraries: ['clusterer', 'drawing', 'services'],
+  });
+  const { markers, selectedPlace, setSelectedPlace } = useKaKaoMap();
+
+  const handleSelectPlace = (place: MarkerType) => {
+    setSelectedPlace(place);
+    onChange({
+      id: place.id,
+      title: place.placeName,
+      address: place.addressName,
+      latitude: place.position.lat,
+      longitude: place.position.lng,
+    });
+  };
+
+  if (loading || error) return <Skeleton className="w-full h-[350px]" />;
+
+  return (
+    <div className="flex flex-col-reverse gap-2">
+      <Map
+        center={{
+          lat: 33.5563,
+          lng: 126.79581,
+        }}
+        className="w-full h-[350px]"
+        level={3}
+      >
+        <KaKaoMapSearch />
+
+        {markers.map((marker) => (
+          <MapMarker key={marker.id} position={marker.position} onClick={() => handleSelectPlace(marker)}>
+            {selectedPlace && selectedPlace.placeName === marker.placeName && (
+              <div className="p-2 rounded-md border-gray-50">{marker.placeName}</div>
+            )}
+          </MapMarker>
+        ))}
+      </Map>
+    </div>
+  );
+};

--- a/apps/admin/src/app/(admin)/session/(component)/kakao-map-search.tsx
+++ b/apps/admin/src/app/(admin)/session/(component)/kakao-map-search.tsx
@@ -1,0 +1,76 @@
+import type { ChangeEvent } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { ScrollArea } from '@/components/ui/scroll-area';
+
+import type { MarkerType } from '../(context)/kakao-map-context';
+import { useKaKaoMap } from '../(context)/kakao-map-context';
+import { type SessionForm as SessionFormType } from '../(data)/session';
+import { useKaKaoMapSearch } from '../(hook)/use-kakao-map-search';
+
+export const KaKaoMapSearch = () => {
+  const form = useFormContext<SessionFormType>();
+
+  const { search, setSearch, searchPlace } = useKaKaoMapSearch();
+  const { markers, selectedPlace, setSelectedPlace } = useKaKaoMap();
+
+  const handleChangeSearchInput = (event: ChangeEvent<HTMLInputElement>) => {
+    setSearch(event.target.value);
+  };
+
+  const handleSelectPlace = (place: MarkerType) => {
+    setSelectedPlace(place);
+    form.setValue('place', {
+      id: place.id,
+      title: place.placeName,
+      address: place.addressName,
+      latitude: place.position.lat,
+      longitude: place.position.lng,
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <Input value={search} onChange={handleChangeSearchInput} />
+        <Button type="button" onClick={searchPlace} className="flex-shrink-0">
+          검색하기
+        </Button>
+      </div>
+
+      {markers.length > 0 && (
+        <ScrollArea className="flex flex-col gap-2 p-4 rounded-md border border-gray-200 max-h-[250px]">
+          {markers.map((marker) => (
+            <PlaceItem
+              key={marker.id}
+              place={marker}
+              isSelected={selectedPlace?.id === marker.id}
+              onSelectPlace={() => handleSelectPlace(marker)}
+            />
+          ))}
+        </ScrollArea>
+      )}
+    </div>
+  );
+};
+
+interface PlaceItemProps {
+  place: MarkerType;
+  isSelected?: boolean;
+  onSelectPlace: () => void;
+}
+
+const PlaceItem = ({ place, isSelected, onSelectPlace }: PlaceItemProps) => {
+  return (
+    <button
+      type="button"
+      onClick={onSelectPlace}
+      className={`flex gap-2 p-2 w-full text-sm hover:bg-gray-50 ${isSelected ? 'bg-gray-100' : ''}`}
+    >
+      <span className="font-semibold">{place.placeName}</span>
+      <span className="text-gray-500">{place.addressName}</span>
+    </button>
+  );
+};

--- a/apps/admin/src/app/(admin)/session/(component)/session-form.tsx
+++ b/apps/admin/src/app/(admin)/session/(component)/session-form.tsx
@@ -12,9 +12,11 @@ import { Textarea } from '@/components/ui/textarea';
 import { toast } from '@/hooks/use-toast';
 
 import { SESSION_TYPES } from '../(constant)/session';
+import KaKaoMapProvider from '../(context)/kakao-map-context';
 import { type SessionForm as SessionFormType } from '../(data)/session';
 
 import { DateTimePicker } from './date-time-picker';
+import { KaKaoMapForm } from './kakao-map-form';
 
 interface SessionFormProps {
   onSubmit: ReturnType<typeof useCreateSession>['mutate'];
@@ -23,6 +25,8 @@ interface SessionFormProps {
 export const SessionForm = ({ onSubmit }: SessionFormProps) => {
   const router = useRouter();
   const form = useFormContext<SessionFormType>();
+
+  const isOffline = form.watch('type') === 'OFFLINE';
 
   const handleDateSelect = (selectedDate?: Date) => {
     if (!selectedDate) return;
@@ -171,20 +175,23 @@ export const SessionForm = ({ onSubmit }: SessionFormProps) => {
           )}
         />
 
-        {/* TODO: 카카오맵에서 장소 고르기 추가 */}
         <FormField
           control={form.control}
           name="place"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>장소</FormLabel>
-              <FormDescription>오프라인 세션인 경우 세션 장소를 입력해주세요.</FormDescription>
-              <FormControl>
-                <Input type="text" placeholder="오프라인일 경우 세션 장소를 입력해주세요" {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
+          render={({ field }) =>
+            isOffline ? (
+              <FormItem>
+                <FormLabel>장소</FormLabel>
+                <FormDescription>오프라인 세션인 경우 세션 장소를 입력해주세요.</FormDescription>
+                <KaKaoMapProvider>
+                  <KaKaoMapForm {...field} />
+                </KaKaoMapProvider>
+                <FormMessage />
+              </FormItem>
+            ) : (
+              <></>
+            )
+          }
         />
 
         <Button type="submit" form="session-form" className="w-full" disabled={!form.formState.isValid}>

--- a/apps/admin/src/app/(admin)/session/(component)/session-preview.tsx
+++ b/apps/admin/src/app/(admin)/session/(component)/session-preview.tsx
@@ -10,11 +10,10 @@ import type { SessionForm } from '../(data)/session';
 
 export const SessionPreview = () => {
   const { watch } = useFormContext<SessionForm>();
-
   const session = watch();
 
   return (
-    <div className="w-[375px] h-[670px] p-6 mx-auto my-auto bg-white rounded-xl shadow-xl invisible lg:visible">
+    <div className="w-[375px] h-[670px] p-6 mx-auto bg-white rounded-xl shadow-xl invisible lg:visible fixed lg:right-[10%] top-[calc(20vh)]">
       <IconLeft />
 
       <H5 className="my-[24px]">{`디프만 ${CURRENT_GENERATION}기 일정`}</H5>
@@ -31,38 +30,36 @@ const SessionItem = ({ week, type, startTime, title, description, place }: Sessi
   const day = getDay(startTime);
 
   return (
-    <>
-      <div className="flex flex-col p-[20px] gap-[20px] rounded-xl bg-white border border-gray-200">
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2">
-            <Badge className="px-2 py-1 rounded-md border-none bg-gray-200 text-gray-500">{week}주차</Badge>
-            <p className="text-[14px] font-semibold">{`${month}월 ${day}일`}</p>
-          </div>
+    <div className="flex flex-col p-[20px] gap-[20px] rounded-xl bg-white border border-gray-200">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Badge className="px-2 py-1 rounded-md border-none bg-gray-200 text-gray-500">{week}주차</Badge>
+          <p className="text-[14px] font-semibold">{`${month}월 ${day}일`}</p>
+        </div>
 
-          {isOffline ? (
-            <Badge className="px-2 py-1 rounded-md border-none bg-gray-900 text-white">오프라인</Badge>
-          ) : (
-            <Badge className="px-2 py-1 rounded-md border-none bg-white text-gray-900 border border-gray-900">
-              온라인
-            </Badge>
+        {isOffline ? (
+          <Badge className="px-2 py-1 rounded-md border-none bg-gray-900 text-white">오프라인</Badge>
+        ) : (
+          <Badge className="px-2 py-1 rounded-md border-none bg-white text-gray-900 border border-gray-900">
+            온라인
+          </Badge>
+        )}
+      </div>
+
+      <div className="flex flex-col">
+        <div className="flex flex-col gap-2">
+          <p className="text-[16px] font-semibold">{title || '세션 이름을 입력해주세요.'}</p>
+          <p className="text-gray-500">{description || '세션 설명을 입력해주세요.'}</p>
+
+          {isOffline && (
+            <button className="flex justify-between items-center py-[12px] my-[8px] rounded-[6px] border border-gray-200 px-4 bg-white text-gray-500">
+              <span className="flex items-center gap-2 text-[12px] text-gray-400">
+                {place?.title || '장소를 입력해주세요'}
+              </span>
+            </button>
           )}
         </div>
-
-        <div className="flex flex-col">
-          <div className="flex flex-col gap-2">
-            <p className="text-[16px] font-semibold">{title || '세션 이름을 입력해주세요.'}</p>
-            <p className="text-gray-500">{description || '세션 설명을 입력해주세요.'}</p>
-
-            {isOffline && (
-              <button className="flex justify-between items-center py-[12px] my-[8px] rounded-[6px] border border-gray-200 px-4 bg-white text-gray-500">
-                <span className="flex items-center gap-2 text-[12px] text-gray-400">
-                  {place || '장소를 입력해주세요'}
-                </span>
-              </button>
-            )}
-          </div>
-        </div>
       </div>
-    </>
+    </div>
   );
 };

--- a/apps/admin/src/app/(admin)/session/(context)/kakao-map-context.tsx
+++ b/apps/admin/src/app/(admin)/session/(context)/kakao-map-context.tsx
@@ -1,0 +1,44 @@
+import type { Dispatch, PropsWithChildren, SetStateAction } from 'react';
+import { createContext, useContext, useState } from 'react';
+
+export interface MarkerType {
+  id: string;
+  position: {
+    lat: number;
+    lng: number;
+  };
+  placeName: string;
+  addressName: string;
+}
+
+interface UsersContextType {
+  markers: MarkerType[];
+  setMarkers: Dispatch<SetStateAction<MarkerType[]>>;
+  selectedPlace?: MarkerType;
+  setSelectedPlace: Dispatch<SetStateAction<MarkerType | undefined>>;
+}
+
+const KaKaoMapContext = createContext<UsersContextType | null>(null);
+
+const KaKaoMapProvider = ({ children }: PropsWithChildren) => {
+  const [markers, setMarkers] = useState<MarkerType[]>([]);
+  const [selectedPlace, setSelectedPlace] = useState<MarkerType>();
+
+  return (
+    <KaKaoMapContext.Provider value={{ markers, setMarkers, selectedPlace, setSelectedPlace }}>
+      {children}
+    </KaKaoMapContext.Provider>
+  );
+};
+
+export const useKaKaoMap = () => {
+  const kaKaoMapContext = useContext(KaKaoMapContext);
+
+  if (!kaKaoMapContext) {
+    throw new Error('<kaKaoMapContext /> 내부에서 useKaKaoMap을 사용할 수 있어요.');
+  }
+
+  return kaKaoMapContext;
+};
+
+export default KaKaoMapProvider;

--- a/apps/admin/src/app/(admin)/session/(data)/session.ts
+++ b/apps/admin/src/app/(admin)/session/(data)/session.ts
@@ -16,6 +16,8 @@ export const sessionScheme = z.object({
   }),
   place: z
     .object({
+      id: z.string(),
+      title: z.string(),
       address: z.string(),
       latitude: z.number(),
       longitude: z.number(),

--- a/apps/admin/src/app/(admin)/session/(hook)/use-kakao-map-search.tsx
+++ b/apps/admin/src/app/(admin)/session/(hook)/use-kakao-map-search.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { useMap } from 'react-kakao-maps-sdk';
+
+import { useKaKaoMap } from '../(context)/kakao-map-context';
+
+export const useKaKaoMapSearch = () => {
+  const map = useMap();
+  const { setMarkers } = useKaKaoMap();
+
+  const [search, setSearch] = useState('');
+
+  const searchPlace = () => {
+    const { keywordSearch } = new kakao.maps.services.Places();
+
+    keywordSearch(search, (placeSearchResult, status, _pagination) => {
+      if (status !== kakao.maps.services.Status.OK) return;
+
+      const bounds = new kakao.maps.LatLngBounds();
+
+      const searchResults = placeSearchResult.map((place) => {
+        bounds.extend(new kakao.maps.LatLng(+place.y, +place.x));
+
+        return {
+          id: place.id,
+          position: {
+            lat: +place.y,
+            lng: +place.x,
+          },
+          placeName: place.place_name,
+          addressName: place.address_name,
+        };
+      });
+
+      setMarkers(searchResults);
+
+      map.setBounds(bounds);
+    });
+  };
+
+  return {
+    search,
+    setSearch,
+    searchPlace,
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       react-hook-form:
         specifier: ^7.54.2
         version: 7.54.2(react@18.3.1)
+      react-kakao-maps-sdk:
+        specifier: ^1.1.27
+        version: 1.1.27(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       sonner:
         specifier: ^1.7.4
         version: 1.7.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6856,6 +6859,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  kakao.maps.d.ts@0.1.40:
+    resolution: {integrity: sha512-nX69MB1ok04epe3OqS+/tEeWBbU31GSQbvDPJmQRRltzzqn6t4jBsO5v1nzalUjCKzwcH2CptOc767NZ7Hbu3g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -8159,6 +8165,12 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-kakao-maps-sdk@1.1.27:
+    resolution: {integrity: sha512-1EwYkYsjTDRFqysKStDasFMrFTXcLx2AyRlqMoWD7ONWhRqpjx9M874hkhEEHrnypP2eSIhhDLe0EiSKp3bd2Q==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18
+      react-dom: ^16.8 || ^17 || ^18
 
   react-native-gesture-handler@2.20.2:
     resolution: {integrity: sha512-HqzFpFczV4qCnwKlvSAvpzEXisL+Z9fsR08YV5LfJDkzuArMhBu2sOoSPUF/K62PCoAb+ObGlTC83TKHfUd0vg==}
@@ -18851,6 +18863,8 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  kakao.maps.d.ts@0.1.40: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -20305,6 +20319,13 @@ snapshots:
   react-is@18.1.0: {}
 
   react-is@18.3.1: {}
+
+  react-kakao-maps-sdk@1.1.27(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.26.0
+      kakao.maps.d.ts: 0.1.40
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-native-gesture-handler@2.20.2(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
# 💡 기능

- 오프라인 세션 장소를 검색할 때 카카오맵을 통해서 검색할 수 있어요.

- 장소를 검색하면 검색 결과가 지도에 마커로 보여요.

- 마커를 클릭하거나 검색 결과를 누르면 해당 장소를 `<세션 미리보기 />` 에서 볼 수 있어요

# 🔎 기타

- 세션 정보 타입 수정 

  - 카카오맵 장소 id, title을 추가했어요